### PR TITLE
Connected the TariffSDK delegate methods to the example app

### DIFF
--- a/GiniTariffSDK/Example/GiniTariffSDK.xcodeproj/project.pbxproj
+++ b/GiniTariffSDK/Example/GiniTariffSDK.xcodeproj/project.pbxproj
@@ -275,12 +275,13 @@
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
-						DevelopmentTeam = 5ARZ8DHL7Z;
+						DevelopmentTeam = JA825X8F7Z;
 						LastSwiftMigration = 0820;
+						ProvisioningStyle = Automatic;
 					};
 					607FACE41AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
-						DevelopmentTeam = 5ARZ8DHL7Z;
+						DevelopmentTeam = JA825X8F7Z;
 						LastSwiftMigration = 0820;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 607FACCF1AFB9204008FA782;
@@ -584,13 +585,15 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = 5ARZ8DHL7Z;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = JA825X8F7Z;
 				INFOPLIST_FILE = GiniTariffSDK/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = net.gini.tariff.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
@@ -600,13 +603,16 @@
 			baseConfigurationReference = DBBE0DF57DCF411A5837179B /* Pods-GiniTariffSDK_Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 5ARZ8DHL7Z;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = JA825X8F7Z;
 				INFOPLIST_FILE = GiniTariffSDK/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = net.gini.tariff.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
@@ -617,7 +623,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = 5ARZ8DHL7Z;
+				DEVELOPMENT_TEAM = JA825X8F7Z;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -643,7 +649,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = 5ARZ8DHL7Z;
+				DEVELOPMENT_TEAM = JA825X8F7Z;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",

--- a/GiniTariffSDK/Example/GiniTariffSDK/TariffExampleViewController.swift
+++ b/GiniTariffSDK/Example/GiniTariffSDK/TariffExampleViewController.swift
@@ -23,6 +23,7 @@ class TariffExampleViewController: UIViewController {
     
     @IBAction func onStartSdk() {
         let sdk = TariffSdk(clientId: "TestId", clientSecret: "secret", domain: "gini.net")
+        sdk.delegate = self
         let tariffController = sdk.instantiateTariffViewController()
         self.present(tariffController, animated: true) { 
             // TODO: maybe show a "thank you" note
@@ -31,3 +32,42 @@ class TariffExampleViewController: UIViewController {
 
 }
 
+extension TariffExampleViewController: TariffSdkDelegate {
+    
+    func tariffSdkDidStart(sdk:TariffSdk) {
+        
+    }
+    
+    func tariffSdk(sdk:TariffSdk, didCapture image:UIImage) {
+        
+    }
+    
+    func tariffSdk(sdk:TariffSdk, didUpload image:UIImage) {
+        
+    }
+    
+    func tariffSdk(sdk:TariffSdk, didReview image:UIImage) {
+        
+    }
+    
+    func tariffSdkDidExtractionsComplete(sdk:TariffSdk) {
+        self.dismiss(animated: true, completion: nil)
+    }
+    
+    func tariffSdk(sdk:TariffSdk, didExtractInfo info:NSData) {
+        
+    }
+    
+    func tariffSdk(sdk:TariffSdk, didReceiveError error:Error) {
+        
+    }
+    
+    func tariffSdk(sdk:TariffSdk, didFailWithError error:Error) {
+        
+    }
+    
+    func tariffSdkDidCancel(sdk:TariffSdk) {
+        self.dismiss(animated: true, completion: nil)
+    }
+    
+}

--- a/GiniTariffSDK/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/GiniTariffSDK/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		1AB7934C16CE49DE196FFC7BE7278287 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D97545C39C4A5EE2631DD9FFECE76A40 /* SwiftSupport.swift */; };
 		1E8A7584520737945B40C78E957EC305 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C6E88A450A84E3957158B3B3459740AA /* Foundation.framework */; };
 		230B0A2A1ED48D1400892467 /* MotionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 230B0A281ED48D1100892467 /* MotionManager.swift */; };
+		230B0A2C1ED4914800892467 /* TariffSdkStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 230B0A2B1ED4914800892467 /* TariffSdkStorage.swift */; };
 		231026E31EC0A7A900920F40 /* TariffConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 231026E21EC0A7A900920F40 /* TariffConfiguration.swift */; };
 		231026E51EC0A91300920F40 /* TariffLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 231026E41EC0A91300920F40 /* TariffLogger.swift */; };
 		231026E71EC0AB4100920F40 /* TariffConsoleLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 231026E61EC0AB4100920F40 /* TariffConsoleLogger.swift */; };
@@ -91,6 +92,7 @@
 		1374B79237CAC07693E99442FBED1F15 /* FBSnapshotTestController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FBSnapshotTestController.h; path = FBSnapshotTestCase/FBSnapshotTestController.h; sourceTree = "<group>"; };
 		13E9B47E0977D77E575DF4C57049677C /* GiniTariffSDK.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = GiniTariffSDK.xcconfig; sourceTree = "<group>"; };
 		230B0A281ED48D1100892467 /* MotionManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MotionManager.swift; path = Classes/MotionManager.swift; sourceTree = "<group>"; };
+		230B0A2B1ED4914800892467 /* TariffSdkStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TariffSdkStorage.swift; path = Classes/TariffSdkStorage.swift; sourceTree = "<group>"; };
 		231026E21EC0A7A900920F40 /* TariffConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TariffConfiguration.swift; path = Classes/TariffConfiguration.swift; sourceTree = "<group>"; };
 		231026E41EC0A91300920F40 /* TariffLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TariffLogger.swift; path = Classes/TariffLogger.swift; sourceTree = "<group>"; };
 		231026E61EC0AB4100920F40 /* TariffConsoleLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TariffConsoleLogger.swift; path = Classes/TariffConsoleLogger.swift; sourceTree = "<group>"; };
@@ -269,6 +271,7 @@
 				232CFB761EC4CD4A009D464A /* PageCollectionViewCell.swift */,
 				2383D1A01ECC46ED00FF91FD /* MultiPageCoordinator.swift */,
 				2383D1A21ECC69AE00FF91FD /* UIStoryboard+Tariff.swift */,
+				2383D19E1ECC46AA00FF91FD /* ReviewViewController.swift */,
 				2399D8891ED32FC40006D523 /* ExtractionsViewController.swift */,
 				2399D8951ED3411D0006D523 /* ExtractionsTableViewCell.swift */,
 			);
@@ -378,8 +381,8 @@
 				23EB017F1EC06602000AB2D9 /* TariffSdk.swift */,
 				23EB01831EC070D1000AB2D9 /* TariffUserInterface.swift */,
 				231026F21EC1EB3A00920F40 /* Tariff.storyboard */,
-				2383D19E1ECC46AA00FF91FD /* ReviewViewController.swift */,
 				2399D8971ED43F790006D523 /* PresentationStyle.swift */,
+				230B0A2B1ED4914800892467 /* TariffSdkStorage.swift */,
 			);
 			path = GiniTariffSDK;
 			sourceTree = "<group>";
@@ -655,6 +658,7 @@
 				2399D8921ED337210006D523 /* ExtractionCollection.swift in Sources */,
 				231027101EC4B63600920F40 /* PagesCollectionViewController.swift in Sources */,
 				2383D1A31ECC69AE00FF91FD /* UIStoryboard+Tariff.swift in Sources */,
+				230B0A2C1ED4914800892467 /* TariffSdkStorage.swift in Sources */,
 				2383D19F1ECC46AA00FF91FD /* ReviewViewController.swift in Sources */,
 				2399D88E1ED334480006D523 /* Extraction.swift in Sources */,
 				2310270C1EC4748300920F40 /* CameraOptionsViewController.swift in Sources */,

--- a/GiniTariffSDK/Example/Tests/TariffSdkTests.swift
+++ b/GiniTariffSDK/Example/Tests/TariffSdkTests.swift
@@ -100,4 +100,8 @@ extension TariffSdkTests: TariffSdkDelegate {
         
     }
     
+    func tariffSdkDidCancel(sdk: TariffSdk) {
+        
+    }
+    
 }

--- a/GiniTariffSDK/GiniTariffSDK/Assets/Tariff.storyboard
+++ b/GiniTariffSDK/GiniTariffSDK/Assets/Tariff.storyboard
@@ -202,7 +202,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Sel-3V-d1q" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1362.4000000000001" y="139.880059970015"/>
+            <point key="canvasLocation" x="2113" y="140"/>
         </scene>
         <!--Extractions View Controller-->
         <scene sceneID="hsB-Zx-Q2Y">
@@ -225,6 +225,9 @@
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nLj-V8-HUP">
                                 <rect key="frame" x="16" y="553" width="343" height="30"/>
                                 <state key="normal" title="Jetzt Stromanbieter wechseln"/>
+                                <connections>
+                                    <action selector="onSwitchTapped" destination="Tcw-tt-dPw" eventType="touchUpInside" id="YJ3-87-bRa"/>
+                                </connections>
                             </button>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="85" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="agV-Ao-7bG">
                                 <rect key="frame" x="16" y="65" width="343" height="472"/>
@@ -303,7 +306,7 @@
         <!--View Controller-->
         <scene sceneID="btW-mp-ZP9">
             <objects>
-                <viewController id="xqs-uQ-KM6" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="ExtractionsCompletedViewController" id="xqs-uQ-KM6" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="tQC-sx-OyZ"/>
                         <viewControllerLayoutGuide type="bottom" id="kxe-FB-M4R"/>

--- a/GiniTariffSDK/GiniTariffSDK/Classes/ExtractionsViewController.swift
+++ b/GiniTariffSDK/GiniTariffSDK/Classes/ExtractionsViewController.swift
@@ -31,6 +31,10 @@ class ExtractionsViewController: UIViewController {
         super.viewWillDisappear(animated)
         navigationController?.isNavigationBarHidden = true
     }
+    
+    @IBAction func onSwitchTapped() {
+        TariffSdkStorage.activeTariffSdk?.delegate?.tariffSdkDidExtractionsComplete(sdk: TariffSdkStorage.activeTariffSdk!)
+    }
 
 }
 

--- a/GiniTariffSDK/GiniTariffSDK/Classes/MultiPageCoordinator.swift
+++ b/GiniTariffSDK/GiniTariffSDK/Classes/MultiPageCoordinator.swift
@@ -79,7 +79,7 @@ extension MultiPageCoordinator: PagesCollectionViewControllerDelegate {
             
         }
         let leaveAction = UIAlertAction(title: NSLocalizedString("Verlassen", comment: "Leave SDK actionsheet leave title"), style: .destructive) { (action) in
-            
+            TariffSdkStorage.activeTariffSdk?.delegate?.tariffSdkDidCancel(sdk: TariffSdkStorage.activeTariffSdk!)
         }
         actionSheet.addAction(cancelAction)
         actionSheet.addAction(leaveAction)

--- a/GiniTariffSDK/GiniTariffSDK/Classes/TariffSdk.swift
+++ b/GiniTariffSDK/GiniTariffSDK/Classes/TariffSdk.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol TariffSdkDelegate: class {
+public protocol TariffSdkDelegate: class {
     
     // TODO: make methods optional
     func tariffSdkDidStart(sdk:TariffSdk)
@@ -19,16 +19,17 @@ protocol TariffSdkDelegate: class {
     func tariffSdk(sdk:TariffSdk, didExtractInfo info:NSData)  // TODO: replace info with a real object
     func tariffSdk(sdk:TariffSdk, didReceiveError error:Error)
     func tariffSdk(sdk:TariffSdk, didFailWithError error:Error)
+    func tariffSdkDidCancel(sdk:TariffSdk)
     
 }
 
 public class TariffSdk {
     
-    let clientId: String
-    let clientSecret: String
-    let clientDomain: String
+    public let clientId: String
+    public let clientSecret: String
+    public let clientDomain: String
     
-    weak var delegate:TariffSdkDelegate? = nil
+    public weak var delegate:TariffSdkDelegate? = nil
     
     let userInterface = TariffUserInterface()
     
@@ -42,6 +43,7 @@ public class TariffSdk {
         self.clientId = clientId
         self.clientSecret = clientSecret
         self.clientDomain = domain
+        TariffSdkStorage.activeTariffSdk = self     // TODO: Don't use TariffSdkStorage - find a better solution
     }
     
     public func instantiateTariffViewController() -> UIViewController {

--- a/GiniTariffSDK/GiniTariffSDK/Classes/TariffSdkStorage.swift
+++ b/GiniTariffSDK/GiniTariffSDK/Classes/TariffSdkStorage.swift
@@ -1,0 +1,17 @@
+//
+//  TariffSdkStorage.swift
+//  Pods
+//
+//  Created by Nikola Sobadjiev on 23.05.17.
+//
+//
+
+import UIKit
+
+// TODO: There should be a better way to access the Tariff SDK object, but for now, 
+// this will have to do
+class TariffSdkStorage {
+
+    static var activeTariffSdk:TariffSdk? = nil
+    
+}


### PR DESCRIPTION
# Introduction

In order to showcase starting and dismissing the Tariff SDK, I connected the TariffSdk delegate methods for cancelling and completing the extraction process to the example app. In order to provide SDK classes access to the currently active TariffSdk object, I'm temporary using `TariffSdkStorage` (I would like to avoid making singleton). It doesn't look very nice, but gets the job done. I'll refactor it once I start working on the network layer.

# How to test

Run all unit tests and also in the example app, try to exit the SDK prematurely (Overflow button -> Leave). After going to the extractions screen, you can also tap on the "Tariff change" button and see if you return to the start screen.

# Merge info

Automatic.