### PR TITLE
Added UI customizations to SdkBuilder to show  how to change appearance parameters

### DIFF
--- a/GiniTariffSDK/Example/GiniTariffSDK.xcodeproj/project.pbxproj
+++ b/GiniTariffSDK/Example/GiniTariffSDK.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		2399D8941ED340490006D523 /* ExtractionsTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2399D8931ED340490006D523 /* ExtractionsTableViewCellTests.swift */; };
 		23A2DCC61ECB3A5B006093E2 /* MultiPageCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A2DCC51ECB3A5B006093E2 /* MultiPageCoordinatorTests.swift */; };
 		23A533711ED8389200EB2229 /* TariffAppearanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A533701ED8389200EB2229 /* TariffAppearanceTests.swift */; };
+		23A533C71EE6D58D00EB2229 /* SdkBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A533C61EE6D58D00EB2229 /* SdkBuilder.swift */; };
 		23EB01821EC066AF000AB2D9 /* TariffSdkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EB01811EC066AF000AB2D9 /* TariffSdkTests.swift */; };
 		23EB01861EC07162000AB2D9 /* TariffUserInterfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EB01851EC07162000AB2D9 /* TariffUserInterfaceTests.swift */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
@@ -67,6 +68,7 @@
 		2399D8931ED340490006D523 /* ExtractionsTableViewCellTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtractionsTableViewCellTests.swift; sourceTree = "<group>"; };
 		23A2DCC51ECB3A5B006093E2 /* MultiPageCoordinatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultiPageCoordinatorTests.swift; sourceTree = "<group>"; };
 		23A533701ED8389200EB2229 /* TariffAppearanceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TariffAppearanceTests.swift; sourceTree = "<group>"; };
+		23A533C61EE6D58D00EB2229 /* SdkBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SdkBuilder.swift; sourceTree = "<group>"; };
 		23EB01811EC066AF000AB2D9 /* TariffSdkTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TariffSdkTests.swift; sourceTree = "<group>"; };
 		23EB01851EC07162000AB2D9 /* TariffUserInterfaceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TariffUserInterfaceTests.swift; sourceTree = "<group>"; };
 		36E73D8BC7FE58332DC0B4DC /* Pods-GiniTariffSDK_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GiniTariffSDK_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-GiniTariffSDK_Tests/Pods-GiniTariffSDK_Tests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -153,6 +155,7 @@
 			children = (
 				607FACD51AFB9204008FA782 /* AppDelegate.swift */,
 				607FACD71AFB9204008FA782 /* TariffExampleViewController.swift */,
+				23A533C61EE6D58D00EB2229 /* SdkBuilder.swift */,
 				607FACD91AFB9204008FA782 /* Main.storyboard */,
 				607FACDC1AFB9204008FA782 /* Images.xcassets */,
 				607FACDE1AFB9204008FA782 /* LaunchScreen.xib */,
@@ -432,6 +435,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				23A533C71EE6D58D00EB2229 /* SdkBuilder.swift in Sources */,
 				607FACD81AFB9204008FA782 /* TariffExampleViewController.swift in Sources */,
 				607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */,
 			);

--- a/GiniTariffSDK/Example/GiniTariffSDK/SdkBuilder.swift
+++ b/GiniTariffSDK/Example/GiniTariffSDK/SdkBuilder.swift
@@ -1,0 +1,36 @@
+//
+//  SdkBuilder.swift
+//  GiniTariffSDK
+//
+//  Created by Nikola Sobadjiev on 06.06.17.
+//  Copyright © 2017 CocoaPods. All rights reserved.
+//
+
+import UIKit
+import GiniTariffSDK
+
+struct SdkBuilder {
+
+    static func customizedTariffSdk() -> TariffSdk {
+        let sdk = TariffSdk(clientId: "TestId", clientSecret: "secret", domain: "gini.net")
+        
+        // Change the main colors
+        sdk.appearance.positiveColor = UIColor(colorLiteralRed: 32.0 / 255.0, green: 186.0 / 255.0, blue: 167.0 / 255.0, alpha: 1.0)
+        sdk.appearance.negativeColor = UIColor(colorLiteralRed: 204.0 / 255.0, green: 33.0 / 255.0, blue: 102.0 / 255.0, alpha: 1.0)
+        sdk.appearance.screenBackgroundColor = UIColor.black
+        
+        // change the exit action sheet text
+        sdk.appearance.exitActionSheetTitle = NSLocalizedString("Leave Gini Switch verlassen?", comment: "Leave SDK actionsheet title")
+        
+        // change the text of the extractions screen button
+        sdk.appearance.extractionsButtonText = NSLocalizedString("Complete the process!", comment: "Extraction screen switch provider title")
+        
+        // change the colors of the extractions screen
+        sdk.appearance.extractionTitleTextColor = UIColor.lightGray
+        sdk.appearance.extractionsScreenTitleText = NSLocalizedString("We have extractions!", comment: "Extraction screen title")
+        sdk.appearance.extractionsTextFieldTextColor = UIColor.gray
+        sdk.appearance.extractionsTextFieldBackgroundColor = UIColor.lightGray
+        
+        return sdk
+    }
+}

--- a/GiniTariffSDK/Example/GiniTariffSDK/TariffExampleViewController.swift
+++ b/GiniTariffSDK/Example/GiniTariffSDK/TariffExampleViewController.swift
@@ -22,7 +22,7 @@ class TariffExampleViewController: UIViewController {
     }
     
     @IBAction func onStartSdk() {
-        let sdk = TariffSdk(clientId: "TestId", clientSecret: "secret", domain: "gini.net")
+        let sdk = SdkBuilder.customizedTariffSdk()
         sdk.delegate = self
         let tariffController = sdk.instantiateTariffViewController()
         self.present(tariffController, animated: true) { 


### PR DESCRIPTION
# Introduction

Added `SdkBuilder` to Tariff SDK sample app to showcase who users can customise the UI. It contains code that changes many of the supported fields.

# How to test

There are no unit tests so you can change some parameters in `SdkBuilder`, run the sample app and see if they got applied.

# Merge info

None.