### PR TITLE
Added API calls for uploading documents

### DIFF
--- a/GiniTariffSDK/Example/GiniTariffSDK.xcodeproj/project.pbxproj
+++ b/GiniTariffSDK/Example/GiniTariffSDK.xcodeproj/project.pbxproj
@@ -27,13 +27,15 @@
 		2399D8941ED340490006D523 /* ExtractionsTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2399D8931ED340490006D523 /* ExtractionsTableViewCellTests.swift */; };
 		23A2DCC61ECB3A5B006093E2 /* MultiPageCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A2DCC51ECB3A5B006093E2 /* MultiPageCoordinatorTests.swift */; };
 		23A533711ED8389200EB2229 /* TariffAppearanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A533701ED8389200EB2229 /* TariffAppearanceTests.swift */; };
-		23A533C71EE6D58D00EB2229 /* SdkBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A533C61EE6D58D00EB2229 /* SdkBuilder.swift */; };
 		23A533B31EDDB46B00EB2229 /* UserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A533B21EDDB46B00EB2229 /* UserTests.swift */; };
 		23A533B71EDDBA5300EB2229 /* TokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A533B61EDDBA5300EB2229 /* TokenTests.swift */; };
 		23A533C31EDF035900EB2229 /* UserManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A533C21EDF035900EB2229 /* UserManagerTests.swift */; };
+		23A533C71EE6D58D00EB2229 /* SdkBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A533C61EE6D58D00EB2229 /* SdkBuilder.swift */; };
 		23A533C91EE82EAF00EB2229 /* AuthenticatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A533C81EE82EAF00EB2229 /* AuthenticatorTests.swift */; };
 		23A533CB1EE831BF00EB2229 /* NoOpWebService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A533CA1EE831BF00EB2229 /* NoOpWebService.swift */; };
 		23A533CD1EE8354400EB2229 /* MemoryCredentialsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A533CC1EE8354400EB2229 /* MemoryCredentialsStore.swift */; };
+		23A533D11EE944DA00EB2229 /* ExtractionResourcesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A533D01EE944DA00EB2229 /* ExtractionResourcesTests.swift */; };
+		23A533D71EE9A2F000EB2229 /* ExtractionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A533D61EE9A2F000EB2229 /* ExtractionServiceTests.swift */; };
 		23EB01821EC066AF000AB2D9 /* TariffSdkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EB01811EC066AF000AB2D9 /* TariffSdkTests.swift */; };
 		23EB01861EC07162000AB2D9 /* TariffUserInterfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EB01851EC07162000AB2D9 /* TariffUserInterfaceTests.swift */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
@@ -74,13 +76,15 @@
 		2399D8931ED340490006D523 /* ExtractionsTableViewCellTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtractionsTableViewCellTests.swift; sourceTree = "<group>"; };
 		23A2DCC51ECB3A5B006093E2 /* MultiPageCoordinatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultiPageCoordinatorTests.swift; sourceTree = "<group>"; };
 		23A533701ED8389200EB2229 /* TariffAppearanceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TariffAppearanceTests.swift; sourceTree = "<group>"; };
-		23A533C61EE6D58D00EB2229 /* SdkBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SdkBuilder.swift; sourceTree = "<group>"; };
 		23A533B21EDDB46B00EB2229 /* UserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserTests.swift; sourceTree = "<group>"; };
 		23A533B61EDDBA5300EB2229 /* TokenTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenTests.swift; sourceTree = "<group>"; };
 		23A533C21EDF035900EB2229 /* UserManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserManagerTests.swift; sourceTree = "<group>"; };
+		23A533C61EE6D58D00EB2229 /* SdkBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SdkBuilder.swift; sourceTree = "<group>"; };
 		23A533C81EE82EAF00EB2229 /* AuthenticatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticatorTests.swift; sourceTree = "<group>"; };
 		23A533CA1EE831BF00EB2229 /* NoOpWebService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NoOpWebService.swift; path = Mocks/NoOpWebService.swift; sourceTree = "<group>"; };
 		23A533CC1EE8354400EB2229 /* MemoryCredentialsStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MemoryCredentialsStore.swift; path = Mocks/MemoryCredentialsStore.swift; sourceTree = "<group>"; };
+		23A533D01EE944DA00EB2229 /* ExtractionResourcesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtractionResourcesTests.swift; sourceTree = "<group>"; };
+		23A533D61EE9A2F000EB2229 /* ExtractionServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtractionServiceTests.swift; sourceTree = "<group>"; };
 		23EB01811EC066AF000AB2D9 /* TariffSdkTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TariffSdkTests.swift; sourceTree = "<group>"; };
 		23EB01851EC07162000AB2D9 /* TariffUserInterfaceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TariffUserInterfaceTests.swift; sourceTree = "<group>"; };
 		36E73D8BC7FE58332DC0B4DC /* Pods-GiniTariffSDK_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GiniTariffSDK_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-GiniTariffSDK_Tests/Pods-GiniTariffSDK_Tests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -215,6 +219,8 @@
 				23A533B61EDDBA5300EB2229 /* TokenTests.swift */,
 				23A533C21EDF035900EB2229 /* UserManagerTests.swift */,
 				23A533C81EE82EAF00EB2229 /* AuthenticatorTests.swift */,
+				23A533D01EE944DA00EB2229 /* ExtractionResourcesTests.swift */,
+				23A533D61EE9A2F000EB2229 /* ExtractionServiceTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -464,6 +470,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				232CFB751EC4CB44009D464A /* PageCollectionViewCellTests.swift in Sources */,
+				23A533D11EE944DA00EB2229 /* ExtractionResourcesTests.swift in Sources */,
 				23A533711ED8389200EB2229 /* TariffAppearanceTests.swift in Sources */,
 				231026F71EC1F35100920F40 /* MultiPageScanViewControllerTests.swift in Sources */,
 				23A533B71EDDBA5300EB2229 /* TokenTests.swift in Sources */,
@@ -474,6 +481,7 @@
 				2399D8901ED336C50006D523 /* ExtractionCollectionTests.swift in Sources */,
 				23A533CB1EE831BF00EB2229 /* NoOpWebService.swift in Sources */,
 				23A2DCC61ECB3A5B006093E2 /* MultiPageCoordinatorTests.swift in Sources */,
+				23A533D71EE9A2F000EB2229 /* ExtractionServiceTests.swift in Sources */,
 				232CFB7A1EC9D18E009D464A /* ScanPageTests.swift in Sources */,
 				2399D8881ED32FAC0006D523 /* ExtractionsViewControllerTests.swift in Sources */,
 				23A533C31EDF035900EB2229 /* UserManagerTests.swift in Sources */,

--- a/GiniTariffSDK/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/GiniTariffSDK/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -51,6 +51,9 @@
 		23A533C11EDF02E100EB2229 /* UserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A533C01EDF02E100EB2229 /* UserManager.swift */; };
 		23A533C51EE03E7800EB2229 /* Authenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A533C41EE03E7800EB2229 /* Authenticator.swift */; };
 		23A533CF1EE8472400EB2229 /* URL+QueryParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A533CE1EE8472400EB2229 /* URL+QueryParameters.swift */; };
+		23A533D31EE945B000EB2229 /* ExtractionResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A533D21EE945B000EB2229 /* ExtractionResources.swift */; };
+		23A533D51EE9725200EB2229 /* TokenUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A533D41EE9725200EB2229 /* TokenUtils.swift */; };
+		23A533DA1EE9A38D00EB2229 /* ExtractionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A533D91EE9A38D00EB2229 /* ExtractionService.swift */; };
 		23EB01801EC06602000AB2D9 /* TariffSdk.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EB017F1EC06602000AB2D9 /* TariffSdk.swift */; };
 		23EB01841EC070D1000AB2D9 /* TariffUserInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EB01831EC070D1000AB2D9 /* TariffUserInterface.swift */; };
 		2F485B69F51E4F723A38410F31F08550 /* FBSnapshotTestController.h in Headers */ = {isa = PBXBuildFile; fileRef = 1374B79237CAC07693E99442FBED1F15 /* FBSnapshotTestController.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -137,6 +140,9 @@
 		23A533C01EDF02E100EB2229 /* UserManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserManager.swift; path = Classes/UserManager.swift; sourceTree = "<group>"; };
 		23A533C41EE03E7800EB2229 /* Authenticator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Authenticator.swift; path = Classes/Authenticator.swift; sourceTree = "<group>"; };
 		23A533CE1EE8472400EB2229 /* URL+QueryParameters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "URL+QueryParameters.swift"; path = "Classes/URL+QueryParameters.swift"; sourceTree = "<group>"; };
+		23A533D21EE945B000EB2229 /* ExtractionResources.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ExtractionResources.swift; path = Classes/ExtractionResources.swift; sourceTree = "<group>"; };
+		23A533D41EE9725200EB2229 /* TokenUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TokenUtils.swift; path = Classes/TokenUtils.swift; sourceTree = "<group>"; };
+		23A533D91EE9A38D00EB2229 /* ExtractionService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ExtractionService.swift; path = Classes/ExtractionService.swift; sourceTree = "<group>"; };
 		23EB017F1EC06602000AB2D9 /* TariffSdk.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TariffSdk.swift; path = Classes/TariffSdk.swift; sourceTree = "<group>"; };
 		23EB01831EC070D1000AB2D9 /* TariffUserInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TariffUserInterface.swift; path = Classes/TariffUserInterface.swift; sourceTree = "<group>"; };
 		2EECE81A9AEC1ED1057A9C3C88DBCEBE /* UIApplication+StrictKeyWindow.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIApplication+StrictKeyWindow.m"; path = "FBSnapshotTestCase/Categories/UIApplication+StrictKeyWindow.m"; sourceTree = "<group>"; };
@@ -334,6 +340,7 @@
 			children = (
 				23A533BB1EDDCC7C00EB2229 /* WebService.swift */,
 				23A533CE1EE8472400EB2229 /* URL+QueryParameters.swift */,
+				23A533D41EE9725200EB2229 /* TokenUtils.swift */,
 			);
 			name = Network;
 			sourceTree = "<group>";
@@ -346,6 +353,15 @@
 				23A533C41EE03E7800EB2229 /* Authenticator.swift */,
 			);
 			name = Authentication;
+			sourceTree = "<group>";
+		};
+		23A533D81EE9A37100EB2229 /* Extractions */ = {
+			isa = PBXGroup;
+			children = (
+				23A533D21EE945B000EB2229 /* ExtractionResources.swift */,
+				23A533D91EE9A38D00EB2229 /* ExtractionService.swift */,
+			);
+			name = Extractions;
 			sourceTree = "<group>";
 		};
 		2753122D9740DD251BEE70B18A8E209C /* Targets Support Files */ = {
@@ -423,6 +439,7 @@
 		8D969973EF0DECD51A01B3AEBC5CAF42 /* GiniTariffSDK */ = {
 			isa = PBXGroup;
 			children = (
+				23A533D81EE9A37100EB2229 /* Extractions */,
 				23A533BD1EDEC41300EB2229 /* Authentication */,
 				23A533BA1EDDCC4E00EB2229 /* Network */,
 				232CFB7B1EC9D1E8009D464A /* Model */,
@@ -710,9 +727,11 @@
 				231027101EC4B63600920F40 /* PagesCollectionViewController.swift in Sources */,
 				2383D1A31ECC69AE00FF91FD /* UIStoryboard+Tariff.swift in Sources */,
 				23A533BC1EDDCC7C00EB2229 /* WebService.swift in Sources */,
+				23A533D51EE9725200EB2229 /* TokenUtils.swift in Sources */,
 				23A533B51EDDB49300EB2229 /* User.swift in Sources */,
 				230B0A2C1ED4914800892467 /* TariffSdkStorage.swift in Sources */,
 				2383D19F1ECC46AA00FF91FD /* ReviewViewController.swift in Sources */,
+				23A533DA1EE9A38D00EB2229 /* ExtractionService.swift in Sources */,
 				2399D88E1ED334480006D523 /* Extraction.swift in Sources */,
 				2310270C1EC4748300920F40 /* CameraOptionsViewController.swift in Sources */,
 				231026ED1EC0BA6300920F40 /* TariffOnboarding.swift in Sources */,
@@ -722,6 +741,7 @@
 				232CFB781EC4CDFE009D464A /* PageCollectionViewCell.swift in Sources */,
 				231026E31EC0A7A900920F40 /* TariffConfiguration.swift in Sources */,
 				231026F11EC0BBCA00920F40 /* TariffNopAnalytics.swift in Sources */,
+				23A533D31EE945B000EB2229 /* ExtractionResources.swift in Sources */,
 				231026E51EC0A91300920F40 /* TariffLogger.swift in Sources */,
 				23A533C11EDF02E100EB2229 /* UserManager.swift in Sources */,
 				230B0A2A1ED48D1400892467 /* MotionManager.swift in Sources */,

--- a/GiniTariffSDK/Example/Tests/ExtractionResourcesTests.swift
+++ b/GiniTariffSDK/Example/Tests/ExtractionResourcesTests.swift
@@ -1,0 +1,79 @@
+//
+//  ExtractionResourcesTests.swift
+//  GiniTariffSDK
+//
+//  Created by Nikola Sobadjiev on 08.06.17.
+//  Copyright © 2017 CocoaPods. All rights reserved.
+//
+
+import XCTest
+@testable import GiniTariffSDK
+
+class ExtractionResourcesTests: XCTestCase {
+    
+    let token = "testToken"
+    var service = ExtractionResources()
+    
+    override func setUp() {
+        super.setUp()
+        
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testSettingToken() {
+        service.token = token
+        XCTAssertEqual(service.token, token, "ExtractionsService should have a token property")
+    }
+    
+    func testInitializingWithToken() {
+        service = ExtractionResources(token: token)
+        XCTAssertNotNil(service, "ExtractionsService should have an initializer taking a token as parameter")
+    }
+    
+    func testCreatingExtractionOrder() {
+        service.token = token
+        let orderResource = service.createExtractionOrder
+        XCTAssertEqual(orderResource.url, URL(string: "https://switch.gini.net/extractionOrders"), "The create extraction order request URL doesn't match")
+        XCTAssertEqual(orderResource.method, "POST", "The create extraction order request method doesn't match")
+        XCTAssertNil(orderResource.body, "The extraction order request shouldn't have a body")
+        XCTAssertEqual(orderResource.headers["Authorization"], "Bearer \(token)", "The extraction order request should have a bearer authentication header")
+    }
+    
+    func testAddingPage() {
+        service.token = token
+        let imageData = testImageData()
+        let testOrder = "myFirstOrder"
+        let pageResource = service.addPage(imageData: imageData, toOrder: testOrder)
+        XCTAssertEqual(pageResource.url, URL(string: "https://switch.gini.net/extractionOrders/\(testOrder)/pages"), "The add page request URL doesn't match")
+        XCTAssertEqual(pageResource.method, "POST", "The add page request method doesn't match")
+        XCTAssertEqual(pageResource.body, String(data: imageData, encoding: .utf8), "The add page request should have the image data as body")
+        XCTAssertEqual(pageResource.headers["Authorization"], "Bearer \(token)", "The add page request should have a bearer authentication header")
+        XCTAssertEqual(pageResource.headers["Content-Type"], "image/jpeg", "The add page request should have a content type header")
+    }
+    
+    func testExtractionsStatus() {
+        service.token = token
+        let testOrder = "myFirstOrder"
+        let extractionsResource = service.statusFor(order:testOrder)
+        XCTAssertEqual(extractionsResource.url, URL(string: "https://switch.gini.net/extractionOrders/\(testOrder)"), "The extractions status request URL doesn't match")
+        XCTAssertEqual(extractionsResource.method, "GET", "The extractions status request method doesn't match")
+        XCTAssertNil(extractionsResource.body, "The extractions status request shouldn't have a body")
+        XCTAssertEqual(extractionsResource.headers["Authorization"], "Bearer \(token)", "The extractions status request should have a bearer authentication header")
+    }
+    
+    func testDeletePage() {
+        service.token = token
+        let testOrder = "myFirstOrder"
+        let testPage = "myFirstPage"
+        let deleteResource = service.deletePageWith(id: testPage, order:testOrder)
+        XCTAssertEqual(deleteResource.url, URL(string: "https://switch.gini.net/extractionOrders/\(testOrder)/pages/\(testPage)"), "The delete page request URL doesn't match")
+        XCTAssertEqual(deleteResource.method, "DELETE", "The delete page request method doesn't match")
+        XCTAssertNil(deleteResource.body, "The delete page request shouldn't have a body")
+        XCTAssertEqual(deleteResource.headers["Authorization"], "Bearer \(token)", "The delete page request should have a bearer authentication header")
+    }
+    
+}

--- a/GiniTariffSDK/Example/Tests/ExtractionServiceTests.swift
+++ b/GiniTariffSDK/Example/Tests/ExtractionServiceTests.swift
@@ -1,0 +1,95 @@
+//
+//  ExtractionServiceTests.swift
+//  GiniTariffSDK
+//
+//  Created by Nikola Sobadjiev on 08.06.17.
+//  Copyright © 2017 CocoaPods. All rights reserved.
+//
+
+import XCTest
+@testable import GiniTariffSDK
+
+class ExtractionServiceTests: XCTestCase {
+    
+    let token = "testToken"
+    let testOrderId = "testOrder"
+    let testPageId = "testPage"
+    var service:ExtractionService! = nil
+    var stubWebService:NoOpWebService! = nil
+    
+    override func setUp() {
+        super.setUp()
+        service = ExtractionService(token: token)
+    }
+    
+    func testExtractionServiceInit() {
+        XCTAssertNotNil(service, "Should be able to construct a ExtractionService")
+    }
+    
+    func testHasToken() {
+        XCTAssertEqual(service.token, token, "ExtractionService should have a token")
+    }
+    
+    func testHasExtractionResources() {
+        XCTAssertNotNil(service.resources, "ExtractionService should have an ExtractionResources")
+    }
+    
+    func testHasWebService() {
+        XCTAssertNotNil(service.resourceLoader, "ExtractionService should have a WebService")
+    }
+    
+    func testCanSetOrderId() {
+        service.orderId = testOrderId
+        XCTAssertEqual(service.orderId, testOrderId, "Should be able to set the orderId")
+    }
+    
+    func testCreateExtractionOrder() {
+        injectWebService()
+        service.createOrder()
+        XCTAssertEqual(stubWebService.resource as! Resource, service.resources.createExtractionOrder, "Creating an order should try to send the createExtractionOrder resource to the web service")
+    }
+    
+    func testNotUploadingPictureWithoutOrderId() {
+        injectWebService()
+        let newPage = testImageData()
+        service.addPage(data:newPage)
+        XCTAssertNil(stubWebService.resource, "Without a created order, pages shouldn't be sent to the web service")
+    }
+    
+    func testUploadingPicture() {
+        injectWebService()
+        let newPage = testImageData()
+        service.orderId = testOrderId
+        service.addPage(data:newPage)
+        XCTAssertEqual(stubWebService.resource as! Resource, service.resources.addPage(imageData: newPage, toOrder: service.orderId!), "ExtractionService should try to send the picture to the web service")
+    }
+    
+    func testNotDeletingPictureWithoutOrderId() {
+        injectWebService()
+        service.deletePage(id:testPageId)
+        XCTAssertNil(stubWebService.resource, "Without a created order, pages shouldn't be deleted from the web service")
+    }
+    
+    func testDeletingPicture() {
+        injectWebService()
+        service.orderId = testOrderId
+        service.deletePage(id: testPageId)
+        XCTAssertEqual(stubWebService.resource as! Resource, service.resources.deletePageWith(id: testPageId, order: testOrderId), "ExtractionService should try to delete the picture from the web service")
+    }
+    
+    func testRetrievingExtractionStatus() {
+        injectWebService()
+        service.orderId = testOrderId
+        service.fetchExtractionStatus()
+        XCTAssertEqual(stubWebService.resource as! Resource, service.resources.statusFor(order: testOrderId), "ExtractionService should try to retrieve the processing status from the web service")
+    }
+    
+}
+
+extension ExtractionServiceTests {
+    
+    func injectWebService() {
+        stubWebService = NoOpWebService()
+        service.resourceLoader = stubWebService
+    }
+}

--- a/GiniTariffSDK/GiniTariffSDK/Classes/Authenticator.swift
+++ b/GiniTariffSDK/GiniTariffSDK/Classes/Authenticator.swift
@@ -71,7 +71,7 @@ class Authenticator {
         user = userManager.user
         assert(user != nil, "Attempting to create user without credentials")
         let fullUrl = baseUrl.appendingPathComponent(createUserUrlExtension)
-        let authHeaders = bearerAuthHeadersDictWith(token: clientToken!)
+        let authHeaders = Token.bearerAuthHeadersDictWith(token:clientToken!)
         user = userManager.user
         let body = userCredentialsJsonString(for: user!)
         return Resource<Bool>(url: fullUrl, headers: authHeaders, method: "POST", body: body, parseJSON: { json in
@@ -170,18 +170,6 @@ extension Authenticator {
         return ["Authorization": basicAuth]
     }
 
-}
-
-// Bearer tokens
-extension Authenticator {
-    
-    func bearerAuthHeaderWith(token:String) -> String {
-        return "Bearer \(token)"
-    }
-    
-    func bearerAuthHeadersDictWith(token:String) -> [String: String] {
-        return ["Authorization": bearerAuthHeaderWith(token: token), "Content-Type": "application/json"]
-    }
 }
 
 // User

--- a/GiniTariffSDK/GiniTariffSDK/Classes/ExtractionResources.swift
+++ b/GiniTariffSDK/GiniTariffSDK/Classes/ExtractionResources.swift
@@ -1,0 +1,73 @@
+//
+//  ExtractionResources.swift
+//  Pods
+//
+//  Created by Nikola Sobadjiev on 08.06.17.
+//
+//
+
+import UIKit
+
+class ExtractionResources {
+
+    var token:String = ""
+    
+    let baseUrl = URL(string:"https://switch.gini.net")!
+    
+    // paths
+    let extractionOrderUrlExtension = "extractionOrders"
+    let addPageExtension = "pages"  // NOTE: not the complete path - the order id needs to be added before this
+    
+    init() {
+        
+    }
+    
+    init(token: String) {
+        self.token = token
+    }
+    
+    var createExtractionOrder:Resource<Bool> {
+        let fullUrl = baseUrl.appendingPathComponent(extractionOrderUrlExtension)
+        let authHeaders = Token.bearerAuthHeadersDictWith(token: token)
+        return Resource<Bool>(url: fullUrl, headers: authHeaders, method: "POST", body: nil, parseJSON: { json in
+            guard let _ = json as? JSONDictionary else { return nil }
+            // TODO: check for errors
+            return true
+        })
+    }
+    
+    func addPage(imageData:Data, toOrder extractionOrder:String) -> Resource<Bool> {
+        var fullUrl = baseUrl.appendingPathComponent(extractionOrderUrlExtension)
+        fullUrl = fullUrl.appendingPathComponent(extractionOrder)
+        fullUrl = fullUrl.appendingPathComponent(addPageExtension)
+        var authHeaders = Token.bearerAuthHeadersDictWith(token: token)
+        authHeaders["Content-Type"] = "image/jpeg"
+        let body = imageData
+        return Resource<Bool>(url: fullUrl, headers: authHeaders, method: "POST", body: String(data: body, encoding: .utf8), parseJSON: { (json) -> Bool? in
+            // TODO: check for errors
+            return true
+        })
+    }
+    
+    func statusFor(order:String) -> Resource<AnyObject> {
+        var fullUrl = baseUrl.appendingPathComponent(extractionOrderUrlExtension)
+        fullUrl = fullUrl.appendingPathComponent(order)
+        let authHeaders = Token.bearerAuthHeadersDictWith(token: token)
+        return Resource<AnyObject>(url: fullUrl, headers: authHeaders, method: "GET", body: nil, parseJSON: { (json) -> AnyObject? in
+            // TODO: check for errors
+            return nil
+        })
+    }
+    
+    func deletePageWith(id:String, order:String) -> Resource<Bool> {
+        var fullUrl = baseUrl.appendingPathComponent(extractionOrderUrlExtension)
+        fullUrl = fullUrl.appendingPathComponent(order)
+        fullUrl = fullUrl.appendingPathComponent(addPageExtension)
+        fullUrl = fullUrl.appendingPathComponent(id)
+        let authHeaders = Token.bearerAuthHeadersDictWith(token: token)
+        return Resource<Bool>(url: fullUrl, headers: authHeaders, method: "DELETE", body: nil, parseJSON: { (json) -> Bool? in
+            // TODO: check for errors
+            return true
+        })
+    }
+}

--- a/GiniTariffSDK/GiniTariffSDK/Classes/ExtractionService.swift
+++ b/GiniTariffSDK/GiniTariffSDK/Classes/ExtractionService.swift
@@ -1,0 +1,63 @@
+//
+//  ExtractionService.swift
+//  Pods
+//
+//  Created by Nikola Sobadjiev on 08.06.17.
+//
+//
+
+import UIKit
+
+class ExtractionService {
+    
+    let token:String
+    let resources:ExtractionResources
+    var resourceLoader:WebService       // var so a new object can be injected
+    var orderId:String? = nil
+    
+    init(token:String) {
+        self.token = token
+        resources = ExtractionResources(token: token)
+        resourceLoader = UrlSessionWebService()
+    }
+    
+    func createOrder() {
+        resourceLoader.load(resource: resources.createExtractionOrder) { (_) in
+            // TODO: get the order id
+        }
+    }
+    
+    func addPage(data:Data) {
+        guard let order = orderId else {
+            // no extraction order yet
+            // TODO: maybe return an error
+            return
+        }
+        resourceLoader.load(resource: resources.addPage(imageData: data, toOrder: order)) { (_) in
+            // TODO: check for errors
+        }
+    }
+    
+    func deletePage(id:String) {
+        guard let order = orderId else {
+            // no extraction order yet
+            // TODO: maybe return an error
+            return
+        }
+        resourceLoader.load(resource: resources.deletePageWith(id: id, order: order)) { (_) in
+            // TODO: check for errors
+        }
+    }
+    
+    func fetchExtractionStatus() {
+        guard let order = orderId else {
+            // no extraction order yet
+            // TODO: maybe return an error
+            return
+        }
+        resourceLoader.load(resource: resources.statusFor(order: order)) { (_) in
+            // TODO: check for errors
+        }
+    }
+
+}

--- a/GiniTariffSDK/GiniTariffSDK/Classes/TokenUtils.swift
+++ b/GiniTariffSDK/GiniTariffSDK/Classes/TokenUtils.swift
@@ -1,0 +1,28 @@
+//
+//  TokenUtils.swift
+//  Pods
+//
+//  Created by Nikola Sobadjiev on 08.06.17.
+//
+//
+
+import Foundation
+
+extension Token {
+    
+    func bearerAuthHeader() -> String {
+        return Token.bearerAuthHeaderWith(token: accessToken)
+    }
+    
+    func bearerAuthHeadersDict() -> [String: String] {
+        return ["Authorization": bearerAuthHeader(), "Content-Type": "application/json"]
+    }
+    
+    static func bearerAuthHeaderWith(token:String) -> String {
+        return "Bearer \(token)"
+    }
+    
+    static func bearerAuthHeadersDictWith(token:String) -> [String: String] {
+        return ["Authorization": bearerAuthHeaderWith(token: token), "Content-Type": "application/json"]
+    }
+}

--- a/GiniTariffSDK/GiniTariffSDK/Classes/WebService.swift
+++ b/GiniTariffSDK/GiniTariffSDK/Classes/WebService.swift
@@ -42,6 +42,13 @@ extension Resource {
     }
 }
 
+extension Resource: Equatable {
+    
+    static func ==(lhs: Resource, rhs: Resource) -> Bool {
+        return (lhs.url == rhs.url) && (lhs.headers == rhs.headers) && (lhs.method == rhs.method) && (lhs.body == rhs.body)
+    }
+}
+
 /*
  * A networking layer inspired by objc.io and their Swift Talk episode (https://github.com/objcio/S01E01-networking/blob/master/Networking.playground/Contents.swift)
  */


### PR DESCRIPTION
# Introduction

This is the base branch for the extraction service API communication layer. Currently, it contains all the API calls for creating orders, uploading pages, deleting pages and querying order status.

Next steps would be to test those queries against the real API (when it's live), add response handling (in a separate pull request) and finally connect everything together (probably a completely different branch, not originating from `doc-service-api`).

# How to test

No way to do that with the sample app. Just run the unit tests.

# Merge information

I'll do it once the other features are complete.