### PR TITLE
Added network call and overall business logic for receiving extractions

### DIFF
--- a/GiniTariffSDK/Example/GiniTariffSDK.xcodeproj/project.pbxproj
+++ b/GiniTariffSDK/Example/GiniTariffSDK.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		23A533ED1EEAC13A00EB2229 /* AddPageResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A533EC1EEAC13A00EB2229 /* AddPageResponseTests.swift */; };
 		23A533F11EEAD01400EB2229 /* ExtractionStatusResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A533F01EEAD01400EB2229 /* ExtractionStatusResponseTests.swift */; };
 		23A533F31EEECF9900EB2229 /* ExtractionsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A533F21EEECF9900EB2229 /* ExtractionsManagerTests.swift */; };
+		23A533F91EF28B1700EB2229 /* ExtractionValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A533F81EF28B1700EB2229 /* ExtractionValueTests.swift */; };
 		23EB01821EC066AF000AB2D9 /* TariffSdkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EB01811EC066AF000AB2D9 /* TariffSdkTests.swift */; };
 		23EB01861EC07162000AB2D9 /* TariffUserInterfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EB01851EC07162000AB2D9 /* TariffUserInterfaceTests.swift */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
@@ -97,6 +98,7 @@
 		23A533EC1EEAC13A00EB2229 /* AddPageResponseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddPageResponseTests.swift; sourceTree = "<group>"; };
 		23A533F01EEAD01400EB2229 /* ExtractionStatusResponseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtractionStatusResponseTests.swift; sourceTree = "<group>"; };
 		23A533F21EEECF9900EB2229 /* ExtractionsManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtractionsManagerTests.swift; sourceTree = "<group>"; };
+		23A533F81EF28B1700EB2229 /* ExtractionValueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtractionValueTests.swift; sourceTree = "<group>"; };
 		23EB01811EC066AF000AB2D9 /* TariffSdkTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TariffSdkTests.swift; sourceTree = "<group>"; };
 		23EB01851EC07162000AB2D9 /* TariffUserInterfaceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TariffUserInterfaceTests.swift; sourceTree = "<group>"; };
 		36E73D8BC7FE58332DC0B4DC /* Pods-GiniTariffSDK_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GiniTariffSDK_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-GiniTariffSDK_Tests/Pods-GiniTariffSDK_Tests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -239,6 +241,7 @@
 				23A533EC1EEAC13A00EB2229 /* AddPageResponseTests.swift */,
 				23A533F01EEAD01400EB2229 /* ExtractionStatusResponseTests.swift */,
 				23A533F21EEECF9900EB2229 /* ExtractionsManagerTests.swift */,
+				23A533F81EF28B1700EB2229 /* ExtractionValueTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -493,6 +496,7 @@
 				231026F71EC1F35100920F40 /* MultiPageScanViewControllerTests.swift in Sources */,
 				23A533B71EDDBA5300EB2229 /* TokenTests.swift in Sources */,
 				23A533B31EDDB46B00EB2229 /* UserTests.swift in Sources */,
+				23A533F91EF28B1700EB2229 /* ExtractionValueTests.swift in Sources */,
 				233B51A61ECA006400C018B8 /* PageCollectionTests.swift in Sources */,
 				2310270A1EC473C100920F40 /* CameraOptionsViewControllerTests.swift in Sources */,
 				23A533F31EEECF9900EB2229 /* ExtractionsManagerTests.swift in Sources */,

--- a/GiniTariffSDK/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/GiniTariffSDK/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		23A533E91EEAA30100EB2229 /* AddPageResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A533E81EEAA30100EB2229 /* AddPageResponse.swift */; };
 		23A533EF1EEAC72A00EB2229 /* ExtractionStatusResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A533EE1EEAC72A00EB2229 /* ExtractionStatusResponse.swift */; };
 		23A533F51EEED06800EB2229 /* ExtractionsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A533F41EEED06800EB2229 /* ExtractionsManager.swift */; };
+		23A533F71EF289CA00EB2229 /* ExtractionValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A533F61EF289CA00EB2229 /* ExtractionValue.swift */; };
 		23EB01801EC06602000AB2D9 /* TariffSdk.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EB017F1EC06602000AB2D9 /* TariffSdk.swift */; };
 		23EB01841EC070D1000AB2D9 /* TariffUserInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EB01831EC070D1000AB2D9 /* TariffUserInterface.swift */; };
 		2F485B69F51E4F723A38410F31F08550 /* FBSnapshotTestController.h in Headers */ = {isa = PBXBuildFile; fileRef = 1374B79237CAC07693E99442FBED1F15 /* FBSnapshotTestController.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -155,6 +156,7 @@
 		23A533E81EEAA30100EB2229 /* AddPageResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AddPageResponse.swift; path = Classes/AddPageResponse.swift; sourceTree = "<group>"; };
 		23A533EE1EEAC72A00EB2229 /* ExtractionStatusResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ExtractionStatusResponse.swift; path = Classes/ExtractionStatusResponse.swift; sourceTree = "<group>"; };
 		23A533F41EEED06800EB2229 /* ExtractionsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ExtractionsManager.swift; path = Classes/ExtractionsManager.swift; sourceTree = "<group>"; };
+		23A533F61EF289CA00EB2229 /* ExtractionValue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ExtractionValue.swift; path = Classes/ExtractionValue.swift; sourceTree = "<group>"; };
 		23EB017F1EC06602000AB2D9 /* TariffSdk.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TariffSdk.swift; path = Classes/TariffSdk.swift; sourceTree = "<group>"; };
 		23EB01831EC070D1000AB2D9 /* TariffUserInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TariffUserInterface.swift; path = Classes/TariffUserInterface.swift; sourceTree = "<group>"; };
 		2EECE81A9AEC1ED1057A9C3C88DBCEBE /* UIApplication+StrictKeyWindow.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIApplication+StrictKeyWindow.m"; path = "FBSnapshotTestCase/Categories/UIApplication+StrictKeyWindow.m"; sourceTree = "<group>"; };
@@ -336,6 +338,7 @@
 				2399D8911ED337210006D523 /* ExtractionCollection.swift */,
 				23A533B41EDDB49300EB2229 /* User.swift */,
 				23A533B81EDDBE9700EB2229 /* Token.swift */,
+				23A533F61EF289CA00EB2229 /* ExtractionValue.swift */,
 			);
 			name = Model;
 			sourceTree = "<group>";
@@ -778,6 +781,7 @@
 				23A533C11EDF02E100EB2229 /* UserManager.swift in Sources */,
 				230B0A2A1ED48D1400892467 /* MotionManager.swift in Sources */,
 				23A533B91EDDBE9700EB2229 /* Token.swift in Sources */,
+				23A533F71EF289CA00EB2229 /* ExtractionValue.swift in Sources */,
 				231026EB1EC0BA1500920F40 /* TariffAppearance.swift in Sources */,
 				23EB01801EC06602000AB2D9 /* TariffSdk.swift in Sources */,
 				23A533BF1EDEC4A000EB2229 /* CredentialsStore.swift in Sources */,

--- a/GiniTariffSDK/Example/Tests/ExtractionCollectionTests.swift
+++ b/GiniTariffSDK/Example/Tests/ExtractionCollectionTests.swift
@@ -14,16 +14,54 @@ class ExtractionCollectionTests: XCTestCase {
     var extractionCollection:ExtractionCollection! = nil
     let testName = "email"
     let testValue = "hello@gini.net"
+    let testValueAlternative = "hi@gini.net"
+    let extractionName = "myExtraction"
+    
+    override func setUp() {
+        super.setUp()
+        extractionCollection = testCollection()
+    }
     
     func testEmptyCollection() {
         XCTAssertNotNil(ExtractionCollection(), "Should be able to create empty collection")
     }
     
     func testInitWithDict() {
-        extractionCollection = ExtractionCollection(dictionary: [testName:testValue])
+        XCTAssertNotNil(extractionCollection, "ExtractionCollection should be able to get parsed from a dictionary")
         let extraction = extractionCollection.extractions.first
-        XCTAssertEqual(extraction?.name, testName, "The key of the dictionary should match the extraction's name")
-        XCTAssertEqual(extraction?.value, testValue, "The value of the dictionary should match the extraction's value")
+        XCTAssertEqual(extraction?.name, extractionName, "ExtractionCollection should be able to parse the extraction's name")
+        XCTAssertEqual(extraction?.value.valueString, testValue, "ExtractionCollection should be able to parse the extraction's value")
     }
     
+    func testInitExtractionName() {
+        let extraction = extractionCollection.extractions.first
+        XCTAssertEqual(extraction?.name, extractionName, "ExtractionCollection should be able to parse the extraction's name")
+    }
+    
+    func testInitExtractionValue() {
+        let extraction = extractionCollection.extractions.first
+        XCTAssertEqual(extraction?.value.valueString, testValue, "ExtractionCollection should be able to parse the extraction's value")
+    }
+    
+    func testInitAlternatives() {
+        let extraction = extractionCollection.extractions.first
+        XCTAssertEqual(extraction?.alternatives.count, 1, "ExtractionCollection should be able to parse the extraction's alternative values")
+    }
+    
+    func testinitAlternativeValue() {
+        let extraction = extractionCollection.extractions.first
+        XCTAssertEqual(extraction?.alternatives.first?.valueString, testValueAlternative, "ExtractionCollection should be able to parse the extraction's alternative value")
+    }
+}
+
+extension ExtractionCollectionTests {
+    
+    func testDict() -> JSONDictionary {
+        return [extractionName: ["value": testValue as AnyObject, "alternatives": [["value": testValueAlternative, "unit": "mails"]] as AnyObject] as AnyObject]
+    }
+    
+    func testCollection() -> ExtractionCollection? {
+        let dict = testDict()
+        return ExtractionCollection(dictionary: dict)
+    }
 }

--- a/GiniTariffSDK/Example/Tests/ExtractionResourcesTests.swift
+++ b/GiniTariffSDK/Example/Tests/ExtractionResourcesTests.swift
@@ -56,7 +56,7 @@ class ExtractionResourcesTests: XCTestCase {
         XCTAssertEqual(pageResource.headers["Content-Type"], "image/jpeg", "The add page request should have a content type header")
     }
     
-    func testExtractionsStatus() {
+    func testOrderStatus() {
         service.token = token
         let testOrderId = "testId"
         let testOrder = "https://switch.gini.net/extractionOrders/\(testOrderId)/pages"
@@ -75,6 +75,17 @@ class ExtractionResourcesTests: XCTestCase {
         let deleteResource = service.deletePageWith(id: testPage, orderUrl:testOrder)
         XCTAssertEqual(deleteResource.url, URL(string: "\(testOrder)/\(testPage)"), "The delete page request URL doesn't match")
         XCTAssertEqual(deleteResource.method, "DELETE", "The delete page request method doesn't match")
+        XCTAssertNil(deleteResource.body, "The delete page request shouldn't have a body")
+        XCTAssertEqual(deleteResource.headers["Authorization"], "Bearer \(token)", "The delete page request should have a bearer authentication header")
+    }
+    
+    func testExtractionsStatus() {
+        service.token = token
+        let testOrderId = "testId"
+        let testOrder = "https://switch.gini.net/extractionOrders/\(testOrderId)"
+        let deleteResource = service.extractionsFor(orderUrl: testOrder)
+        XCTAssertEqual(deleteResource.url, URL(string: "\(testOrder)/extractions"), "The delete page request URL doesn't match")
+        XCTAssertEqual(deleteResource.method, "GET", "The delete page request method doesn't match")
         XCTAssertNil(deleteResource.body, "The delete page request shouldn't have a body")
         XCTAssertEqual(deleteResource.headers["Authorization"], "Bearer \(token)", "The delete page request should have a bearer authentication header")
     }

--- a/GiniTariffSDK/Example/Tests/ExtractionServiceTests.swift
+++ b/GiniTariffSDK/Example/Tests/ExtractionServiceTests.swift
@@ -21,11 +21,13 @@ class ExtractionServiceTests: XCTestCase {
     var orderCallBack:ExtractionServiceOrderCallback!
     var pageCallBack:ExtractionServicePageCallback!
     var statusCallback:ExtractionServiceStatusCallback!
+    var extractionsCallback:ExtractionServiceExtractionsCallback!
     
     // callback params
     var returnedError:Error? = nil
     var returnedId:String? = nil
     var returnedStatus:ExtractionStatusResponse? = nil
+    var returnedExtractions:ExtractionCollection? = nil
     
     override func setUp() {
         super.setUp()
@@ -41,6 +43,10 @@ class ExtractionServiceTests: XCTestCase {
         }
         statusCallback = { [weak self](status, error) -> Void in
             self?.returnedStatus = status
+            self?.returnedError = error
+        }
+        extractionsCallback = { [weak self](collection, error) -> Void in
+            self?.returnedExtractions = collection
             self?.returnedError = error
         }
     }
@@ -100,11 +106,18 @@ class ExtractionServiceTests: XCTestCase {
         XCTAssertEqual(stubWebService.resource as! Resource, service.resources.deletePageWith(id: testPageId, orderUrl: testOrderUrl), "ExtractionService should try to delete the picture from the web service")
     }
     
-    func testRetrievingExtractionStatus() {
+    func testRetrievingOrderStatus() {
         injectWebService()
         service.orderUrl = testOrderUrl
-        service.fetchExtractionStatus(completion: statusCallback)
+        service.fetchOrderStatus(completion: statusCallback)
         XCTAssertEqual(stubWebService.resource as! Resource, service.resources.statusFor(orderUrl: testOrderUrl), "ExtractionService should try to retrieve the processing status from the web service")
+    }
+    
+    func testRetrievingExtractions() {
+        injectWebService()
+        service.orderUrl = testOrderUrl
+        service.fetchExtractions(completion: extractionsCallback)
+        XCTAssertEqual(stubWebService.resource as! Resource, service.resources.extractionsFor(orderUrl: testOrderUrl), "ExtractionService should try to retrieve the extractions from the web service")
     }
     
 }

--- a/GiniTariffSDK/Example/Tests/ExtractionTests.swift
+++ b/GiniTariffSDK/Example/Tests/ExtractionTests.swift
@@ -14,26 +14,43 @@ class ExtractionTests: XCTestCase {
     var extraction:Extraction! = nil
     let testName = "email"
     let testValue = "hello@gini.net"
+    let testValueAlternative = "hi@gini.net"
     
     override func setUp() {
         super.setUp()
-        extraction = Extraction()
+        extraction = Extraction(name: testName, value: testValue as AnyObject)
     }
     
     func testHasName() {
-        extraction.name = testName
         XCTAssertEqual(extraction.name, testName, "An Extraction should have a name")
     }
     
     func testHasValue() {
-        extraction.value = testValue
-        XCTAssertEqual(extraction.value, testValue, "An Extraction should have a value")
+        XCTAssertEqual(extraction.valueString, testValue, "An Extraction should have a value")
     }
     
     func testInitWithParameters() {
-        extraction = Extraction(name:testName, value:testValue)
+        extraction = Extraction(name:testName, value:testValue as AnyObject)
         XCTAssertEqual(extraction.name, testName, "An Extraction should use the name provided in the init")
-        XCTAssertEqual(extraction.value, testValue, "An Extraction should use the value provided in the init")
+        XCTAssertEqual(extraction.valueString, testValue, "An Extraction should use the value provided in the init")
     }
     
+    func testInitWithDict() {
+        extraction = Extraction(name:testName, dict:extractionDict())
+        XCTAssertEqual(extraction.name, testName, "An Extraction should use the name provided in the init")
+        XCTAssertEqual(extraction.valueString, testValue, "An Extraction should use the value provided in the init")
+    }
+    
+    func testHasAlternatives() {
+        extraction = Extraction(name:testName, dict:extractionDict())
+        let alternative = extraction.alternatives.first
+        XCTAssertEqual(alternative?.valueString, testValueAlternative, "Extraction should be able to parse the alternatives")
+    }
+}
+
+extension ExtractionTests {
+    
+    func extractionDict() -> JSONDictionary {
+        return ["value": testValue as AnyObject, "alternatives": [["value": testValueAlternative, "unit": "mails"]] as AnyObject]
+    }
 }

--- a/GiniTariffSDK/Example/Tests/ExtractionValueTests.swift
+++ b/GiniTariffSDK/Example/Tests/ExtractionValueTests.swift
@@ -1,0 +1,36 @@
+//
+//  ExtractionValueTests.swift
+//  GiniTariffSDK
+//
+//  Created by Nikola Sobadjiev on 15.06.17.
+//  Copyright © 2017 CocoaPods. All rights reserved.
+//
+
+import XCTest
+@testable import GiniTariffSDK
+
+class ExtractionValueTests: XCTestCase {
+    
+    let extraction = ExtractionValue(value:11.34 as AnyObject, unit:"sample data")
+    
+    func testHasAccessValue() {
+        XCTAssertEqual(extraction.value as? Double, 11.34, "ExtractionValue objects should have a value property")
+    }
+    
+    func testHasUnit() {
+        XCTAssertEqual(extraction.unit, "sample data", "Token objects should have a unit property")
+    }
+    
+    func testInitFromDictionary() {
+        let dict:JSONDictionary = ["value": Float(123.121) as AnyObject, "unit": "myUnit" as AnyObject]
+        let dictExtraction = ExtractionValue(dictionary: dict)
+        XCTAssertNotNil(dictExtraction, "Should be able to initialize an ExtractionValue from a dictionary")
+    }
+    
+    func testUnitIsOptional() {
+        let dict:JSONDictionary = ["value": Float(123.121) as AnyObject]
+        let dictExtraction = ExtractionValue(dictionary: dict)
+        XCTAssertNotNil(dictExtraction, "Should be able to initialize an ExtractionValue from a dictionary without a unit")
+    }
+    
+}

--- a/GiniTariffSDK/Example/Tests/ExtractionsTableViewCellTests.swift
+++ b/GiniTariffSDK/Example/Tests/ExtractionsTableViewCellTests.swift
@@ -18,7 +18,9 @@ class ExtractionsTableViewCellTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        extractionCell = initializeCellFromStoryboard(extractionCollection: ExtractionCollection(dictionary:[testField:testValue]))
+        let extraction = Extraction(name: testField, value: testValue as AnyObject)
+        let collection = ExtractionCollection(collection: [extraction])
+        extractionCell = initializeCellFromStoryboard(extractionCollection: collection)
     }
     
     func testHasNameLabel() {

--- a/GiniTariffSDK/Example/Tests/ExtractionsViewControllerTests.swift
+++ b/GiniTariffSDK/Example/Tests/ExtractionsViewControllerTests.swift
@@ -53,8 +53,7 @@ class ExtractionsViewControllerTests: XCTestCase {
     }
     
     func testHasRightNumberOfCells() {
-        var collection = ExtractionCollection()
-        collection.extractions = [Extraction(), Extraction(), Extraction(), Extraction()]
+        let collection = ExtractionCollection(collection:[Extraction(), Extraction(), Extraction(), Extraction()])
         extractionsController.extractionsCollection = collection
         XCTAssertEqual(extractionsController.tableView(extractionsController.extractionsTable, numberOfRowsInSection: 0), 4, "Four extractions should show up as four cells in the ExtractionsViewController")
     }

--- a/GiniTariffSDK/Example/Tests/MultiPageCoordinatorTests.swift
+++ b/GiniTariffSDK/Example/Tests/MultiPageCoordinatorTests.swift
@@ -58,33 +58,15 @@ class MultiPageCoordinatorTests: XCTestCase {
         XCTAssertTrue(fakeCamera.hasCaptured, "If the capture button on the camera options controller is tapped, MultiPageCoordinator should route that to the camera object")
     }
     
-    func testAddingPageAfterCapture() {
-        coordinator.cameraController.takePicture()
-        XCTAssertEqual(coordinator.pageCollectionController.pages?.count, 1, "After taking the picture, the pages collection controller should have one page")
-    }
-    
     func testGoingToReviewAfterCapture() {
         coordinator.cameraController.takePicture()
         XCTAssertTrue(didRequestReviewScreen, "The multiPageCoordinator:requestedShowingController should be invoked in order for the review screen to be presented")
-    }
-    
-    func testReviewScreenPage() {
-        coordinator.cameraController.takePicture()
-        XCTAssertEqual(coordinator.pageCollectionController.pages?.last, requestedReviewScreen?.page, "The page under review, should be the last one in the collection")
     }
     
     func testReviewControllerDismiss() {
         coordinator.cameraController.takePicture()
         requestedReviewScreen?.rejectButtonTapped()
         XCTAssertTrue(didRequestReviewDismiss, "After the image is rejected, the review screen should be dismissed")
-    }
-    
-    func testRejectingPicture() {
-        coordinator.cameraController.takePicture()
-        let pagesNum = coordinator.pageCollectionController.pages?.count
-        requestedReviewScreen?.rejectButtonTapped()
-        let pagesNumAfterReject = coordinator.pageCollectionController.pages?.count
-        XCTAssertEqual(pagesNum! - 1, pagesNumAfterReject, "If an image is rejected, it has to be removed from the list")
     }
     
     func testGoingToExtractions() {

--- a/GiniTariffSDK/GiniTariffSDK/Classes/Extraction.swift
+++ b/GiniTariffSDK/GiniTariffSDK/Classes/Extraction.swift
@@ -6,18 +6,65 @@
 //
 //
 
-struct Extraction {
+class  Extraction {
 
-    var name:String? = nil
-    var value:String? = nil
+    let name:String
+    var value:ExtractionValue = ExtractionValue(value: "" as AnyObject, unit: nil)
+    var alternatives:[ExtractionValue] = []
     
-    init() {
-        
+    var valueString:String {
+        return value.valueString
     }
     
-    init(name:String?, value:String?) {
+    convenience init() {
+        self.init(name: "", value: "" as AnyObject)
+    }
+    
+    init(name:String, value:AnyObject) {
         self.name = name
-        self.value = value
+        self.value = ExtractionValue(value: value, unit: nil)
+        alternatives = []
+    }
+    
+    init(name:String, dict: JSONDictionary) {
+        self.name = name
+        parseValue(dict)
+        parseAlternatives(dict)
+    }
+    
+}
+
+// Parsing
+extension Extraction {
+    
+    func parseValue(_ dict:JSONDictionary) {
+        if let stringValue = dict["value"] as? String {
+            value = ExtractionValue(value: stringValue as AnyObject, unit: nil)
+        }
+        else if let objValue = ExtractionValue(dictionary: dict) {
+            value = objValue
+        }
+    }
+    
+    func parseAlternatives(_ dict:JSONDictionary) {
+        let alternativesDict = dict["alternatives"] as? [JSONDictionary] ?? []
+        alternatives = alternativesDict.flatMap { (altDict) -> ExtractionValue in
+            return ExtractionValue(dictionary: altDict) ?? ExtractionValue(value: "" as AnyObject, unit: nil) // TODO: maybe filter those?
+        }
+    }
+}
+
+extension Extraction:Equatable {
+    
+    static func ==(lhs: Extraction, rhs: Extraction) -> Bool {
+        var equalAlternatives = true
+        for (val1, val2) in zip(lhs.alternatives, rhs.alternatives) {
+            equalAlternatives = equalAlternatives && val1 == val2
+        }
+        return lhs.name == rhs.name &&
+            lhs.value == rhs.value &&
+            equalAlternatives &&
+            lhs.alternatives.count == rhs.alternatives.count
     }
     
 }

--- a/GiniTariffSDK/GiniTariffSDK/Classes/ExtractionCollection.swift
+++ b/GiniTariffSDK/GiniTariffSDK/Classes/ExtractionCollection.swift
@@ -8,22 +8,36 @@
 
 import UIKit
 
-struct ExtractionCollection {
+class ExtractionCollection:BaseApiResponse {
 
-    var extractions:[Extraction] = []
+    let extractions:[Extraction]
     
     init() {
-        
+        extractions = []
+        super.init(href: "")
     }
     
-    init?(dictionary:[String:String]?) {
-        guard let dict = dictionary else {
-            return nil
-        }
+    init(collection:[Extraction]) {
+        extractions = collection
+        super.init(href: "")
+    }
+    
+    init?(dictionary:JSONDictionary) {
+        extractions = dictionary.keys.map { (name) -> Extraction in
+            let extractionDict = dictionary[name] as? JSONDictionary ?? [:]
+            return Extraction(name: name, dict: extractionDict)
+        }.filter({ (extraction) -> Bool in
+            return !extraction.value.valueString.isEmpty    // filter empty extractions
+        })
+        super.init(dict: dictionary)
+    }
+    
+}
 
-        for (name, value) in dict {
-            extractions.append(Extraction(name:name, value:value))
-        }
+extension ExtractionCollection:Equatable {
+    
+    static func ==(lhs: ExtractionCollection, rhs: ExtractionCollection) -> Bool {
+        return lhs.extractions == rhs.extractions
     }
     
 }

--- a/GiniTariffSDK/GiniTariffSDK/Classes/ExtractionResources.swift
+++ b/GiniTariffSDK/GiniTariffSDK/Classes/ExtractionResources.swift
@@ -17,6 +17,7 @@ class ExtractionResources {
     // paths
     let extractionOrderUrlExtension = "extractionOrders"
     let addPageExtension = "pages"  // NOTE: not the complete path - the order id needs to be added before this
+    let extractionsExtension = "extractions"
     
     init() {
         
@@ -68,6 +69,22 @@ class ExtractionResources {
             guard let statusDict = json as? JSONDictionary else { return nil }
             let statusResponse = ExtractionStatusResponse(dict:statusDict)
             return statusResponse
+        })
+    }
+    
+    func extractionsFor(orderUrl:String) -> Resource<ExtractionCollection> {
+        // TODO: Figure out how to return a failing Resource
+        //        guard let fullUrl = URL(string:orderUrl) else {
+        //            // TODO: return error
+        //            assertionFailure("Encountered a malformed url")
+        //        }
+        var fullUrl = URL(string:orderUrl)!
+        fullUrl = fullUrl.appendingPathComponent(extractionsExtension)
+        let authHeaders = Token.bearerAuthHeadersDictWith(token: token)
+        return Resource<ExtractionCollection>(url: fullUrl, headers: authHeaders, method: "GET", body: nil, parseJSON: { (json) in
+            guard let extractionsDict = json as? JSONDictionary else { return nil }
+            let extractionsResponse = ExtractionCollection(dictionary: extractionsDict)
+            return extractionsResponse
         })
     }
     

--- a/GiniTariffSDK/GiniTariffSDK/Classes/ExtractionService.swift
+++ b/GiniTariffSDK/GiniTariffSDK/Classes/ExtractionService.swift
@@ -13,6 +13,7 @@ import UIKit
 typealias ExtractionServiceOrderCallback = (_ url:String?, _ error:Error?) -> Void
 typealias ExtractionServicePageCallback = (_ id:String?, _ error:Error?) -> Void
 typealias ExtractionServiceStatusCallback = (_ status:ExtractionStatusResponse?, _ error:Error?) -> Void    // TODO: should ExtractionStatusResponse be exposed?
+typealias ExtractionServiceExtractionsCallback = (_ collection:ExtractionCollection?, _ error:Error?) -> Void
 
 class ExtractionService {
     
@@ -66,7 +67,7 @@ class ExtractionService {
         }
     }
     
-    func fetchExtractionStatus(completion:ExtractionServiceStatusCallback) {
+    func fetchOrderStatus(completion:ExtractionServiceStatusCallback) {
         guard let order = orderUrl else {
             // no extraction order yet
             // TODO: maybe return an error
@@ -74,6 +75,17 @@ class ExtractionService {
         }
         resourceLoader.load(resource: resources.statusFor(orderUrl: order)) { (status) in
             // TODO: check for errors
+        }
+    }
+    
+    func fetchExtractions(completion:@escaping ExtractionServiceExtractionsCallback) {
+        guard let order = orderUrl else {
+            // no extraction order yet
+            // TODO: maybe return an error
+            return
+        }
+        resourceLoader.load(resource: resources.extractionsFor(orderUrl: order)) { (collection) in
+            completion(collection, nil)
         }
     }
 

--- a/GiniTariffSDK/GiniTariffSDK/Classes/ExtractionValue.swift
+++ b/GiniTariffSDK/GiniTariffSDK/Classes/ExtractionValue.swift
@@ -1,0 +1,34 @@
+//
+//  ExtractionValue.swift
+//  Pods
+//
+//  Created by Nikola Sobadjiev on 15.06.17.
+//
+//
+
+struct ExtractionValue {
+    
+    let value:AnyObject
+    let unit:String?
+    
+    var valueString:String {
+        return "\(value)"
+    }
+    
+    init(value val:AnyObject, unit:String?) {
+        self.value = val
+        self.unit = unit
+    }
+    
+    init?(dictionary:JSONDictionary) {
+        guard let val = dictionary["value"] as AnyObject? else {
+                return nil
+        }
+        self.init(value:val, unit: dictionary["unit"] as? String)
+    }
+    
+    static func ==(lhs: ExtractionValue, rhs: ExtractionValue) -> Bool {
+        return lhs.unit == rhs.unit && lhs.valueString == rhs.valueString
+    }
+
+}

--- a/GiniTariffSDK/GiniTariffSDK/Classes/ExtractionsViewController.swift
+++ b/GiniTariffSDK/GiniTariffSDK/Classes/ExtractionsViewController.swift
@@ -58,7 +58,7 @@ extension ExtractionsViewController: UITableViewDataSource {
         let cell = tableView.dequeueReusableCell(withIdentifier: "ExtractionsTableViewCell", for: indexPath) as! ExtractionsTableViewCell
         let extraction = extractionsCollection?.extractions[indexPath.row]
         cell.nameLabel.text = extraction?.name ?? ""
-        cell.valueTextField.text = extraction?.value ?? ""
+        cell.valueTextField.text = extraction?.valueString ?? ""
         cell.nameLabel.textColor = currentTariffAppearance().extractionTitleTextColor
         cell.valueTextField.textColor = currentTariffAppearance().extractionsTextFieldTextColor
         cell.valueTextField.layer.borderColor = currentTariffAppearance().extractionsTextFieldBorderColor?.cgColor

--- a/GiniTariffSDK/GiniTariffSDK/Classes/MultiPageCoordinator.swift
+++ b/GiniTariffSDK/GiniTariffSDK/Classes/MultiPageCoordinator.swift
@@ -68,10 +68,8 @@ extension MultiPageCoordinator: CameraOptionsViewControllerDelegate {
     
     func cameraControllerIsDone(cameraController:CameraOptionsViewController) {
         let extractionsController = UIStoryboard.tariffStoryboard()?.instantiateViewController(withIdentifier: "ExtractionsViewController") as! ExtractionsViewController
-        // TODO: these are hardcoded extractions for test purposes. In the future, they should come from the API
-        let extractions = ["Name": "Holger", "Adresse": "Sonnenstr.", "Ort": "München", "Zählernummer": "439057928376"]
-        let collection = ExtractionCollection(dictionary: extractions)
-        extractionsController.extractionsCollection = collection
+        extractionsController.extractionsCollection = extractionsManager.extractions
+        extractionsManager.pollExtractions()
         delegate?.multiPageCoordinator(self, requestedShowingController: extractionsController, presentationStyle: .navigation)
     }
 }
@@ -81,7 +79,6 @@ extension MultiPageCoordinator: CameraViewControllerDelegate {
     func cameraViewController(controller:CameraViewController, didCaptureImage data:Data) {
         // create a new scan page
         let newPage = ScanPage(imageData: data, id: nil, status: .taken)
-        self.pageCollectionController.pages?.add(element: newPage)
         showReviewScreen(withPage:newPage)
         enableCaptureButton(true)
     }
@@ -132,8 +129,6 @@ extension MultiPageCoordinator: ReviewViewControllerDelegate {
     }
     
     func reviewController(_ controller:ReviewViewController, didRejectPage page:ScanPage) {
-        pageCollectionController.pages?.remove(page)
-        self.pageCollectionController.pagesCollection?.reloadData()
         self.delegate?.multiPageCoordinator(self, requestedDismissingController: controller, presentationStyle: .modal)
     }
     


### PR DESCRIPTION
# Introduction

This pull request contains the network call for polling extractions and all the changes needed in the business logic to accommodate the new data model it uses. The periodic polling for extractions is still pending.

# How to test

Run the unit tests. Additionally, the ExtractionsViewController should now who real extractions, if there are any. However, that's still largely untested, so it might not be 100% working.

# Merge info

Automatic