### PR TITLE
Fixed EXIF not added unless image is rotated

### DIFF
--- a/GiniTariffSDK/GiniTariffSDK/Classes/ReviewViewController.swift
+++ b/GiniTariffSDK/GiniTariffSDK/Classes/ReviewViewController.swift
@@ -45,7 +45,7 @@ class ReviewViewController: UIViewController {
     var delegate:ReviewViewControllerDelegate? = nil
     
     @IBAction func useButtonTapped() {
-        // TODO: get the current image data since it might have been rotated
+        page?.imageData = metaInformationManager?.imageData()
         delegate?.reviewController(self, didAcceptPage: page!)
     }
     


### PR DESCRIPTION
# Introduction

Another horrible fix proving how bad we need to re-write `ImageMetaInformationManager`.
The EXIF tags weren't added unless the image is rotated and also only the TIFF tags were imported, leaving the EXIF out.

# How to test

Debug...

# Merge info

Automatic