### PR TITLE
Invoking TariffSdkDelegate methods

### DIFF
--- a/GiniTariffSDK/Example/GiniTariffSDK/TariffExampleViewController.swift
+++ b/GiniTariffSDK/Example/GiniTariffSDK/TariffExampleViewController.swift
@@ -35,38 +35,40 @@ class TariffExampleViewController: UIViewController {
 extension TariffExampleViewController: TariffSdkDelegate {
     
     func tariffSdkDidStart(sdk:TariffSdk) {
-        
+        print("Tariff SDK did start")
     }
     
-    func tariffSdk(sdk:TariffSdk, didCapture image:UIImage) {
-        
+    func tariffSdk(sdk:TariffSdk, didCapture imageData:Data) {
+        print("Tariff SDK captured an image")
     }
     
-    func tariffSdk(sdk:TariffSdk, didUpload image:UIImage) {
-        
+    func tariffSdk(sdk:TariffSdk, didUpload imageData:Data) {
+        print("Tariff SDK uploaded an image")
     }
     
-    func tariffSdk(sdk:TariffSdk, didReview image:UIImage) {
-        
+    func tariffSdk(sdk:TariffSdk, didReview imageData:Data) {
+        print("Tariff SDK reviewed an image")
     }
     
-    func tariffSdkDidExtractionsComplete(sdk:TariffSdk) {
+    func tariffSdkDidComplete(sdk:TariffSdk) {
+        print("Tariff SDK completed")
         self.dismiss(animated: true, completion: nil)
     }
     
-    func tariffSdk(sdk:TariffSdk, didExtractInfo info:NSData) {
-        
+    func tariffSdk(sdk:TariffSdk, didExtractInfo info:ExtractionCollection) {
+        print("TariffSDK did receive extractions")
     }
     
     func tariffSdk(sdk:TariffSdk, didReceiveError error:Error) {
-        
+        print("Tariff SDK did receive an error: \(error.localizedDescription)")
     }
     
     func tariffSdk(sdk:TariffSdk, didFailWithError error:Error) {
-        
+        print("Tariff SDK finished with error: \(error.localizedDescription)")
     }
     
     func tariffSdkDidCancel(sdk:TariffSdk) {
+        print("Tariff SDK interrupted")
         self.dismiss(animated: true, completion: nil)
     }
     

--- a/GiniTariffSDK/Example/Tests/TariffSdkTests.swift
+++ b/GiniTariffSDK/Example/Tests/TariffSdkTests.swift
@@ -87,23 +87,23 @@ extension TariffSdkTests: TariffSdkDelegate {
         
     }
     
-    func tariffSdk(sdk:TariffSdk, didCapture image:UIImage) {
+    func tariffSdk(sdk:TariffSdk, didCapture imageData:Data) {
         
     }
     
-    func tariffSdk(sdk:TariffSdk, didUpload image:UIImage) {
+    func tariffSdk(sdk:TariffSdk, didUpload imageData:Data) {
         
     }
     
-    func tariffSdk(sdk:TariffSdk, didReview image:UIImage) {
+    func tariffSdk(sdk:TariffSdk, didReview imageData:Data) {
         
     }
     
-    func tariffSdkDidExtractionsComplete(sdk:TariffSdk) {
+    func tariffSdkDidComplete(sdk:TariffSdk) {
         
     }
     
-    func tariffSdk(sdk:TariffSdk, didExtractInfo info:NSData) {
+    func tariffSdk(sdk:TariffSdk, didExtractInfo info:ExtractionCollection) {
         
     }
     

--- a/GiniTariffSDK/GiniTariffSDK/Classes/BaseApiResponse.swift
+++ b/GiniTariffSDK/GiniTariffSDK/Classes/BaseApiResponse.swift
@@ -12,7 +12,7 @@
  *
  * Other responses should inherit from this class and add their additional elements
  */
-class BaseApiResponse {
+public class BaseApiResponse {
 
     let href:String?
     

--- a/GiniTariffSDK/GiniTariffSDK/Classes/Extraction.swift
+++ b/GiniTariffSDK/GiniTariffSDK/Classes/Extraction.swift
@@ -6,7 +6,7 @@
 //
 //
 
-class  Extraction {
+public class  Extraction {
 
     let name:String
     var value:ExtractionValue = ExtractionValue(value: "" as AnyObject, unit: nil)
@@ -56,7 +56,7 @@ extension Extraction {
 
 extension Extraction:Equatable {
     
-    static func ==(lhs: Extraction, rhs: Extraction) -> Bool {
+    public static func ==(lhs: Extraction, rhs: Extraction) -> Bool {
         var equalAlternatives = true
         for (val1, val2) in zip(lhs.alternatives, rhs.alternatives) {
             equalAlternatives = equalAlternatives && val1 == val2

--- a/GiniTariffSDK/GiniTariffSDK/Classes/ExtractionCollection.swift
+++ b/GiniTariffSDK/GiniTariffSDK/Classes/ExtractionCollection.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class ExtractionCollection:BaseApiResponse {
+public class ExtractionCollection:BaseApiResponse {
 
     let extractions:[Extraction]
     
@@ -34,7 +34,7 @@ class ExtractionCollection:BaseApiResponse {
 
 extension ExtractionCollection:Equatable {
     
-    static func ==(lhs: ExtractionCollection, rhs: ExtractionCollection) -> Bool {
+    public static func ==(lhs: ExtractionCollection, rhs: ExtractionCollection) -> Bool {
         return lhs.extractions == rhs.extractions
     }
     

--- a/GiniTariffSDK/GiniTariffSDK/Classes/ExtractionsManager.swift
+++ b/GiniTariffSDK/GiniTariffSDK/Classes/ExtractionsManager.swift
@@ -120,6 +120,7 @@ class ExtractionsManager {
                 page.id = pageUrl
                 page.status = .uploaded
                 self?.notifyCollectionChanged()
+                currentTariffSdk().delegate?.tariffSdk(sdk: currentTariffSdk(), didUpload: page.imageData)
             }
         })
     }
@@ -238,6 +239,7 @@ class ExtractionsManager {
     
     fileprivate func notifyExtractionsChanged() {
         self.delegate?.extractionsManager(self, didChangeExtractions: extractions)
+        currentTariffSdk().delegate?.tariffSdk(sdk: currentTariffSdk(), didExtractInfo: extractions)
     }
     
     fileprivate func notifyExtractionsComplete() {

--- a/GiniTariffSDK/GiniTariffSDK/Classes/ExtractionsViewController.swift
+++ b/GiniTariffSDK/GiniTariffSDK/Classes/ExtractionsViewController.swift
@@ -35,7 +35,7 @@ class ExtractionsViewController: UIViewController {
     }
     
     @IBAction func onSwitchTapped() {
-        TariffSdkStorage.activeTariffSdk?.delegate?.tariffSdkDidExtractionsComplete(sdk: TariffSdkStorage.activeTariffSdk!)
+        TariffSdkStorage.activeTariffSdk?.delegate?.tariffSdkDidComplete(sdk: TariffSdkStorage.activeTariffSdk!)
     }
 
 }

--- a/GiniTariffSDK/GiniTariffSDK/Classes/MultiPageCoordinator.swift
+++ b/GiniTariffSDK/GiniTariffSDK/Classes/MultiPageCoordinator.swift
@@ -41,6 +41,7 @@ class MultiPageCoordinator {
         extractionsManager.delegate = self
         extractionsManager.authenticate()
         self.extractionsManager.createExtractionOrder()
+        currentTariffSdk().delegate?.tariffSdkDidStart(sdk: currentTariffSdk())
         
         scheduleOnboarding()
     }
@@ -142,6 +143,7 @@ extension MultiPageCoordinator: CameraViewControllerDelegate {
         let newPage = ScanPage(imageData: data, id: nil, status: .taken)
         showReviewScreen(withPage:newPage)
         enableCaptureButton(true)
+        currentTariffSdk().delegate?.tariffSdk(sdk: currentTariffSdk(), didCapture: data)
     }
     
     func cameraViewController(controller:CameraViewController, didFailWithError error:Error) {
@@ -198,6 +200,7 @@ extension MultiPageCoordinator: ReviewViewControllerDelegate {
         }
         refreshPagesCollectionView()
         completeIfReady()
+        currentTariffSdk().delegate?.tariffSdk(sdk: currentTariffSdk(), didReview: page.imageData)
     }
     
     func reviewController(_ controller:ReviewViewController, didRejectPage page:ScanPage) {

--- a/GiniTariffSDK/GiniTariffSDK/Classes/TariffSdk.swift
+++ b/GiniTariffSDK/GiniTariffSDK/Classes/TariffSdk.swift
@@ -12,11 +12,11 @@ public protocol TariffSdkDelegate: class {
     
     // TODO: make methods optional
     func tariffSdkDidStart(sdk:TariffSdk)
-    func tariffSdk(sdk:TariffSdk, didCapture image:UIImage)    // TODO: maybe use NSData?
-    func tariffSdk(sdk:TariffSdk, didUpload image:UIImage)    // TODO: maybe use NSData?
-    func tariffSdk(sdk:TariffSdk, didReview image:UIImage)    // TODO: maybe use NSData?
-    func tariffSdkDidExtractionsComplete(sdk:TariffSdk)
-    func tariffSdk(sdk:TariffSdk, didExtractInfo info:NSData)  // TODO: replace info with a real object
+    func tariffSdk(sdk:TariffSdk, didCapture imageData:Data)    // TODO: maybe use NSData?
+    func tariffSdk(sdk:TariffSdk, didUpload imageData:Data)    // TODO: maybe use NSData?
+    func tariffSdk(sdk:TariffSdk, didReview imageData:Data)    // TODO: maybe use NSData?
+    func tariffSdkDidComplete(sdk:TariffSdk)
+    func tariffSdk(sdk:TariffSdk, didExtractInfo info:ExtractionCollection)  // TODO: replace info with a real object
     func tariffSdk(sdk:TariffSdk, didReceiveError error:Error)
     func tariffSdk(sdk:TariffSdk, didFailWithError error:Error)
     func tariffSdkDidCancel(sdk:TariffSdk)

--- a/GiniTariffSDK/GiniTariffSDK/Classes/TariffSdkStorage.swift
+++ b/GiniTariffSDK/GiniTariffSDK/Classes/TariffSdkStorage.swift
@@ -12,11 +12,19 @@ import UIKit
 // this will have to do
 class TariffSdkStorage {
 
-    static var activeTariffSdk:TariffSdk? = nil
+    static var activeTariffSdk:TariffSdk! = nil
     
 }
 
 /// Convenience method for getting the currently active appearance object
 func currentTariffAppearance() -> TariffAppearance {
-    return TariffSdkStorage.activeTariffSdk?.appearance ?? TariffAppearance()   // TODO: is returning an empty object ok?
+    return TariffSdkStorage.activeTariffSdk.appearance
+}
+
+func currentTariffSdk() -> TariffSdk {
+    return TariffSdkStorage.activeTariffSdk
+}
+
+func Logger() -> TariffLogger {
+    return currentTariffSdk().configuration.logging
 }


### PR DESCRIPTION
# Introduction

`TariffSdkDelegate` is part of the client interface for the SDK. It provides callsbacks for events that occur throughout the SDK's lifecycle

# How to test

Run the test app and look at the console logs - a log message should appear whenever a delegate method is called.

# Merge info

Automatic