### PR TITLE
Fixed check for having a user token returning true for nil tokens

### DIFF
--- a/GiniTariffSDK/GiniTariffSDK/Classes/Authenticator.swift
+++ b/GiniTariffSDK/GiniTariffSDK/Classes/Authenticator.swift
@@ -104,7 +104,7 @@ class Authenticator {
     
     func importCredentials() {
         userToken = credentials.accessToken
-        if userToken?.isEmpty != true {
+        if userToken?.isEmpty == false {
             authState = .userToken
             return
         }


### PR DESCRIPTION
# Introduction

An incorrect check in Authenticator meant that if there was no token (nil) saved in the keychain, the app would think it's already logged in.

# How to test

Install the app in a new device or change the bundle ID to something you have never used before to make sure the keychain has no entries for this app. Make sure the app properly authenticates and is able to upload images

# Merge info

Automatic