### PR TITLE
Bugfix - Completion screen not presented

### DIFF
--- a/GiniSwitchSDK/Example/Tests/MultiPageCoordinatorTests.swift
+++ b/GiniSwitchSDK/Example/Tests/MultiPageCoordinatorTests.swift
@@ -89,7 +89,7 @@ extension MultiPageCoordinatorTests: MultiPageCoordinatorDelegate {
         exitActionSheet = requestedShowingController as? UIAlertController
     }
     
-    func multiPageCoordinator(_ coordinator:MultiPageCoordinator, requestedDismissingController:UIViewController, presentationStyle:PresentationStyle, animated:Bool) {
+    func multiPageCoordinator(_ coordinator:MultiPageCoordinator, requestedDismissingController:UIViewController, presentationStyle:PresentationStyle, animated:Bool, completion:(() -> Void)?) {
         didRequestReviewDismiss = true
     }
     

--- a/GiniSwitchSDK/GiniSwitchSDK/Classes/MultiPageScanViewController.swift
+++ b/GiniSwitchSDK/GiniSwitchSDK/Classes/MultiPageScanViewController.swift
@@ -90,10 +90,10 @@ extension MultiPageScanViewController: MultiPageCoordinatorDelegate {
         }
     }
     
-    func multiPageCoordinator(_ coordinator:MultiPageCoordinator, requestedDismissingController:UIViewController, presentationStyle:PresentationStyle, animated:Bool) {
+    func multiPageCoordinator(_ coordinator:MultiPageCoordinator, requestedDismissingController:UIViewController, presentationStyle:PresentationStyle, animated:Bool, completion: (() -> Void)?) {
         switch presentationStyle {
         case .modal:
-            requestedDismissingController.presentingViewController?.dismiss(animated: animated, completion: nil)
+            requestedDismissingController.presentingViewController?.dismiss(animated: animated, completion: completion)
         case .navigation:
             if self.navigationController?.topViewController == requestedDismissingController {
                 self.navigationController?.popViewController(animated: animated)


### PR DESCRIPTION
# Introduction

The view controller hierarchy was breaking as the completion screen was being presented. As a result it wasn't showing. In this pull request, the app waits until the review screen is dismissed completely before presenting the completion screen.

# How to test

Use a real document to make sure the completion screen shows after several page. Make sure the completion screen shows automatically.

# Merge info 

Automatic