### PR TITLE
Hiding the navigation bar in the sample app

### DIFF
--- a/GiniSwitchSDK/Example/GiniTariffSDK/SwitchExampleViewController.swift
+++ b/GiniSwitchSDK/Example/GiniTariffSDK/SwitchExampleViewController.swift
@@ -16,7 +16,7 @@ class SwitchExampleViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view, typically from a nib.
+        self.navigationController?.isNavigationBarHidden = true
     }
 
     override func didReceiveMemoryWarning() {


### PR DESCRIPTION
# Introduction

There was a navigation bar showing in the example app's screens. It wasn't really useful, so I removed it.

# Merge info

Automatic