### PR TITLE
Invalid token errors

### DIFF
--- a/GiniSwitchSDK/Example/GiniTariffSDK/SwitchExampleViewController.swift
+++ b/GiniSwitchSDK/Example/GiniTariffSDK/SwitchExampleViewController.swift
@@ -16,7 +16,7 @@ class SwitchExampleViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view, typically from a nib.
+        self.navigationController?.isNavigationBarHidden = true
     }
 
     override func didReceiveMemoryWarning() {

--- a/GiniSwitchSDK/GiniSwitchSDK/Classes/ExtractionsManager.swift
+++ b/GiniSwitchSDK/GiniSwitchSDK/Classes/ExtractionsManager.swift
@@ -100,6 +100,7 @@ class ExtractionsManager {
             if self?.tryHandleUnauthorizedError(error) == true {
                 Logger().logInfo(message: "Queueing extraction order creating")
                 self?.shouldRequestOrder = true
+                return
             }
             if error == nil && orderUrl != nil {
                 Logger().logInfo(message: "Created extraction order")


### PR DESCRIPTION
# Introduction

Invalid token errors are handled internally by re-logging in. Nevertheless, the Authenticator class was returning the error so it was making its way to the UI. This is fixed now

# Merge info

Automatic