### PR TITLE
Bugfix memory leaks

### DIFF
--- a/GiniSwitchSDK/Example/GiniTariffSDK/ExtractionsViewController.swift
+++ b/GiniSwitchSDK/Example/GiniTariffSDK/ExtractionsViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import GiniSwitchSDK
 
-protocol ExtractionsViewControllerDelegate {
+protocol ExtractionsViewControllerDelegate:class {
     
     func extractionsControllerDidSwitch(_ controller:ExtractionsViewController)
     func extractionsControllerDidGoBack(_ controller:ExtractionsViewController)
@@ -24,7 +24,7 @@ class ExtractionsViewController: UIViewController {
     @IBOutlet var switchButton:UIButton! = nil
     
     var extractionsCollection:ExtractionCollection? = nil
-    var delegate:ExtractionsViewControllerDelegate? = nil
+    weak var delegate:ExtractionsViewControllerDelegate? = nil
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/GiniSwitchSDK/Example/GiniTariffSDK/SwitchExampleViewController.swift
+++ b/GiniSwitchSDK/Example/GiniTariffSDK/SwitchExampleViewController.swift
@@ -13,6 +13,7 @@ class SwitchExampleViewController: UIViewController {
     
     var extractions = ExtractionCollection()
     var switchController:UIViewController? = nil
+    var sdk:GiniSwitchSdk? = nil
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -25,9 +26,9 @@ class SwitchExampleViewController: UIViewController {
     }
     
     @IBAction func onStartSdk() {
-        let sdk = SdkBuilder.customizedSwitchSdk()
-        sdk.delegate = self
-        switchController = sdk.instantiateSwitchViewController()
+        sdk = SdkBuilder.customizedSwitchSdk()
+        sdk?.delegate = self
+        switchController = sdk?.instantiateSwitchViewController()
         self.present(switchController!, animated: true, completion: nil)
     }
     
@@ -89,6 +90,9 @@ extension SwitchExampleViewController: ExtractionsViewControllerDelegate {
     func extractionsControllerDidSwitch(_ controller:ExtractionsViewController) {
         navigationController?.popViewController(animated: true)
         switchController = nil
+        sdk?.terminate()
+        sdk = nil
+        extractions = ExtractionCollection()        // release the collection
     }
     
     func extractionsControllerDidGoBack(_ controller:ExtractionsViewController) {

--- a/GiniSwitchSDK/GiniSwitchSDK/Classes/ExtractionsManager.swift
+++ b/GiniSwitchSDK/GiniSwitchSDK/Classes/ExtractionsManager.swift
@@ -9,7 +9,7 @@
 
 import UIKit
 
-protocol ExtractionsManagerDelegate {
+protocol ExtractionsManagerDelegate: class {
     
     func extractionsManager(_ manager:ExtractionsManager, didEncounterError error:NSError)
     func extractionsManager(_ manager:ExtractionsManager, didChangePageCollection collection:PageCollection)
@@ -36,7 +36,7 @@ class ExtractionsManager {
     var statusScheduler:PollScheduler? = nil
     var extractionsScheduler:PollScheduler? = nil
     
-    var delegate:ExtractionsManagerDelegate? = nil
+    weak var delegate:ExtractionsManagerDelegate? = nil
     
     // if the create extraction order call comes before the client is authenticated
     // it needs to be queued. shouldRequestOrder is used for that

--- a/GiniSwitchSDK/GiniSwitchSDK/Classes/GiniSwitchSdk.swift
+++ b/GiniSwitchSDK/GiniSwitchSDK/Classes/GiniSwitchSdk.swift
@@ -56,5 +56,9 @@ public class GiniSwitchSdk {
     public func instantiateSwitchViewController() -> UIViewController {
         return userInterface.initialViewController
     }
+    
+    public func terminate() {
+        GiniSwitchSdkStorage.activeSwitchSdk = nil     // TODO: Don't use GiniSwitchSdkStorage - find a better solution
+    }
 
 }

--- a/GiniSwitchSDK/GiniSwitchSDK/Classes/ReviewViewController.swift
+++ b/GiniSwitchSDK/GiniSwitchSDK/Classes/ReviewViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol ReviewViewControllerDelegate {
+protocol ReviewViewControllerDelegate:class {
     
     func reviewController(_ controller:ReviewViewController, didAcceptPage page:ScanPage)
     func reviewController(_ controller:ReviewViewController, didRejectPage page:ScanPage)
@@ -46,7 +46,7 @@ class ReviewViewController: UIViewController {
     var confirmColor:UIColor? = nil
     var denyColor:UIColor? = nil
 
-    var delegate:ReviewViewControllerDelegate? = nil
+    weak var delegate:ReviewViewControllerDelegate? = nil
     
     @IBAction func useButtonTapped() {
         guard let image = metaInformationManager?.imageData() else {


### PR DESCRIPTION
# Introduction

There were several delegates that weren't weak properties and were therefore creating a retain cycle.
Also, the `GiniSwitchSdk` instance wasn't being disposed of properly.

# How to test

In the demo app, after the process is finished, make sure that all SDK classes are released.

# Merge info

Automatic