### PR TITLE
Extraction cells not editable 

### DIFF
--- a/GiniSwitchSDK/Example/GiniTariffSDK/Base.lproj/Main.storyboard
+++ b/GiniSwitchSDK/Example/GiniTariffSDK/Base.lproj/Main.storyboard
@@ -82,7 +82,7 @@
                                 <rect key="frame" x="16" y="45" width="343" height="491"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="ExtractionsTableViewCell" rowHeight="85" id="aSX-ST-uOB" customClass="ExtractionsTableViewCell" customModule="GiniSwitchSDK_Example" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="ExtractionsTableViewCell" rowHeight="85" id="aSX-ST-uOB" customClass="ExtractionsTableViewCell" customModule="GiniSwitchSDK_Example" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="28" width="343" height="85"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="aSX-ST-uOB" id="qMc-vw-7GW">
@@ -95,7 +95,7 @@
                                                     <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" textAlignment="natural" minimumFontSize="17" clearButtonMode="always" translatesAutoresizingMaskIntoConstraints="NO" id="zpg-5v-mg5">
+                                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="zpg-5v-mg5">
                                                     <rect key="frame" x="8" y="29" width="327" height="40"/>
                                                     <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>


### PR DESCRIPTION
# Introduction 

The cells in the extractions screen were editable. Users were able to select them and change the values in the text fields. That was not a desirable behaviour.

 So now, they cannot be selected and the text fields are not interactive.

# How to test

Try to select or edit the extractions you see in the extractions screen

# Merge info

Automatic