### PR TITLE
SDK delegate changes

### DIFF
--- a/GiniSwitchSDK/Example/GiniTariffSDK/SwitchExampleViewController.swift
+++ b/GiniSwitchSDK/Example/GiniTariffSDK/SwitchExampleViewController.swift
@@ -54,46 +54,30 @@ class SwitchExampleViewController: UIViewController {
 
 extension SwitchExampleViewController: GiniSwitchSdkDelegate {
     
-    func switchSdkDidStart(sdk:GiniSwitchSdk) {
-        print("Switch SDK did start")
-    }
-    
-    func switchSdk(sdk:GiniSwitchSdk, didCapture imageData:Data) {
-        print("Switch SDK captured an image")
-    }
-    
-    func switchSdk(sdk:GiniSwitchSdk, didUpload imageData:Data) {
-        print("Switch SDK uploaded an image")
-    }
-    
-    func switchSdk(sdk:GiniSwitchSdk, didReview imageData:Data) {
-        print("Switch SDK reviewed an image")
-    }
-    
-    func switchSdkDidComplete(sdk:GiniSwitchSdk) {
+    func switchSdkDidComplete(_ sdk:GiniSwitchSdk) {
         print("Switch SDK completed")
         self.showExtractions(extractions: self.extractions)
         self.dismiss(animated: true, completion: nil)
     }
     
-    func switchSdk(sdk:GiniSwitchSdk, didExtractInfo info:ExtractionCollection) {
+    func switchSdk(_ sdk:GiniSwitchSdk, didChangeExtractions info:ExtractionCollection) {
         print("Switch SDK did receive extractions")
         extractions = info
     }
     
-    func switchSdk(sdk:GiniSwitchSdk, didReceiveError error:NSError) {
+    func switchSdk(_ sdk:GiniSwitchSdk, didReceiveError error:NSError) {
         print("Switch SDK did receive an error: \(error.localizedDescription)")
         if error.switchErrorCode == .feedbackError {
             terminateSdk()
         }
     }
     
-    func switchSdkDidCancel(sdk:GiniSwitchSdk) {
+    func switchSdkDidCancel(_ sdk:GiniSwitchSdk) {
         print("Switch SDK interrupted")
         self.dismiss(animated: true, completion: nil)
     }
     
-    func switchSdkDidSendFeedback(sdk:GiniSwitchSdk) {
+    func switchSdkDidSendFeedback(_ sdk:GiniSwitchSdk) {
         terminateSdk()
     }
     

--- a/GiniSwitchSDK/Example/Tests/GiniSwitchSdkTests.swift
+++ b/GiniSwitchSDK/Example/Tests/GiniSwitchSdkTests.swift
@@ -83,39 +83,23 @@ extension GiniSwitchSdkTests {
 
 extension GiniSwitchSdkTests: GiniSwitchSdkDelegate {
     
-    func switchSdkDidStart(sdk:GiniSwitchSdk) {
+    func switchSdkDidComplete(_ sdk:GiniSwitchSdk) {
         
     }
     
-    func switchSdk(sdk:GiniSwitchSdk, didCapture imageData:Data) {
+    func switchSdk(_ sdk:GiniSwitchSdk, didChangeExtractions info:ExtractionCollection) {
         
     }
     
-    func switchSdk(sdk:GiniSwitchSdk, didUpload imageData:Data) {
+    func switchSdk(_ sdk:GiniSwitchSdk, didReceiveError error:NSError) {
         
     }
     
-    func switchSdk(sdk:GiniSwitchSdk, didReview imageData:Data) {
+    func switchSdkDidCancel(_ sdk: GiniSwitchSdk) {
         
     }
     
-    func switchSdkDidComplete(sdk:GiniSwitchSdk) {
-        
-    }
-    
-    func switchSdk(sdk:GiniSwitchSdk, didExtractInfo info:ExtractionCollection) {
-        
-    }
-    
-    func switchSdk(sdk:GiniSwitchSdk, didReceiveError error:NSError) {
-        
-    }
-    
-    func switchSdkDidCancel(sdk: GiniSwitchSdk) {
-        
-    }
-    
-    func switchSdkDidSendFeedback(sdk:GiniSwitchSdk) {
+    func switchSdkDidSendFeedback(_ sdk:GiniSwitchSdk) {
         
     }
     

--- a/GiniSwitchSDK/GiniSwitchSDK/Classes/ExtractionsManager.swift
+++ b/GiniSwitchSDK/GiniSwitchSDK/Classes/ExtractionsManager.swift
@@ -138,7 +138,6 @@ class ExtractionsManager {
                 page.id = pageUrl
                 page.status = .uploaded
                 self?.notifyCollectionChanged()
-                currentSwitchSdk().delegate?.switchSdk(sdk: currentSwitchSdk(), didUpload: page.imageData)
             }
         })
     }
@@ -290,7 +289,8 @@ class ExtractionsManager {
     
     fileprivate func notifyExtractionsChanged() {
         self.delegate?.extractionsManager(self, didChangeExtractions: extractions)
-        currentSwitchSdk().delegate?.switchSdk(sdk: currentSwitchSdk(), didExtractInfo: extractions)
+        currentSwitchSdk().extractions = extractions
+        currentSwitchSdk().delegate?.switchSdk(currentSwitchSdk(), didChangeExtractions: extractions)
     }
     
     fileprivate func notifyExtractionsComplete() {

--- a/GiniSwitchSDK/GiniSwitchSDK/Classes/GiniSwitchSdk.swift
+++ b/GiniSwitchSDK/GiniSwitchSDK/Classes/GiniSwitchSdk.swift
@@ -10,16 +10,11 @@ import UIKit
 
 public protocol GiniSwitchSdkDelegate: class {
     
-    // TODO: make methods optional
-    func switchSdkDidStart(sdk:GiniSwitchSdk)
-    func switchSdk(sdk:GiniSwitchSdk, didCapture imageData:Data)
-    func switchSdk(sdk:GiniSwitchSdk, didUpload imageData:Data)
-    func switchSdk(sdk:GiniSwitchSdk, didReview imageData:Data)
-    func switchSdkDidComplete(sdk:GiniSwitchSdk)
-    func switchSdk(sdk:GiniSwitchSdk, didExtractInfo info:ExtractionCollection)
-    func switchSdk(sdk:GiniSwitchSdk, didReceiveError error:NSError)
-    func switchSdkDidCancel(sdk:GiniSwitchSdk)
-    func switchSdkDidSendFeedback(sdk:GiniSwitchSdk)
+    func switchSdk(_ sdk:GiniSwitchSdk, didChangeExtractions extractions:ExtractionCollection)
+    func switchSdk(_ sdk:GiniSwitchSdk, didReceiveError error:NSError)
+    func switchSdkDidCancel(_ sdk:GiniSwitchSdk)
+    func switchSdkDidComplete(_ sdk:GiniSwitchSdk)
+    func switchSdkDidSendFeedback(_ sdk:GiniSwitchSdk)
     
 }
 
@@ -48,6 +43,11 @@ public class GiniSwitchSdk {
     }
     
     var feedbackHandler:((ExtractionCollection) -> Void)! = nil
+    
+    /*
+     * The extractions that have been received so far. 
+     */
+    var extractions:ExtractionCollection = ExtractionCollection()
     
     /*
      * Creates a GiniSwitchSdk instance based on the provided credentials

--- a/GiniSwitchSDK/GiniSwitchSDK/Classes/MultiPageCoordinator.swift
+++ b/GiniSwitchSDK/GiniSwitchSDK/Classes/MultiPageCoordinator.swift
@@ -44,7 +44,6 @@ class MultiPageCoordinator {
         extractionsManager.delegate = self
         extractionsManager.authenticate()
         self.extractionsManager.createExtractionOrder()
-        currentSwitchSdk().delegate?.switchSdkDidStart(sdk: currentSwitchSdk())
         
         if !GiniSwitchOnboarding.hasShownOnboarding {
             scheduleOnboarding()
@@ -117,7 +116,7 @@ class MultiPageCoordinator {
             let delay = DispatchTime.now() + .seconds(extrationsCompletePopupTimeout)
             DispatchQueue.main.asyncAfter(deadline: delay, execute: {
                 myDelegate?.multiPageCoordinator(self, requestedDismissingController: completionController, presentationStyle: .modal, animated: true) {
-                    currentSwitchSdk().delegate?.switchSdkDidComplete(sdk: currentSwitchSdk())
+                    currentSwitchSdk().delegate?.switchSdkDidComplete(currentSwitchSdk())
                 }
             })
         }
@@ -129,7 +128,7 @@ class MultiPageCoordinator {
             
         }
         let leaveAction = UIAlertAction(title: NSLocalizedString("Verlassen", comment: "Leave SDK actionsheet leave title"), style: .destructive) { (action) in
-            currentSwitchSdk().delegate?.switchSdkDidCancel(sdk: currentSwitchSdk())
+            currentSwitchSdk().delegate?.switchSdkDidCancel(currentSwitchSdk())
         }
         let helpAction = UIAlertAction(title: NSLocalizedString("Hilfe", comment: "Leave SDK actionsheet help title"), style: .default) { (action) in
             self.scheduleOnboarding()
@@ -168,7 +167,7 @@ extension MultiPageCoordinator: CameraOptionsViewControllerDelegate {
     
     func cameraControllerIsDone(cameraController:CameraOptionsViewController) {
         extractionsManager.pollExtractions()
-        currentSwitchSdk().delegate?.switchSdkDidComplete(sdk: currentSwitchSdk())
+        currentSwitchSdk().delegate?.switchSdkDidComplete(currentSwitchSdk())
     }
 }
 
@@ -179,7 +178,6 @@ extension MultiPageCoordinator: CameraViewControllerDelegate {
         let newPage = ScanPage(imageData: data, id: nil, status: .taken)
         showReviewScreen(withPage:newPage)
         enableCaptureButton(true)
-        currentSwitchSdk().delegate?.switchSdk(sdk: currentSwitchSdk(), didCapture: data)
     }
     
     func cameraViewController(controller:CameraViewController, didFailWithError error:Error) {
@@ -227,7 +225,6 @@ extension MultiPageCoordinator: ReviewViewControllerDelegate {
             extractionsManager.add(page: page)
         }
         refreshPagesCollectionView()
-        currentSwitchSdk().delegate?.switchSdk(sdk: currentSwitchSdk(), didReview: page.imageData)
     }
     
     func reviewController(_ controller:ReviewViewController, didRejectPage page:ScanPage) {
@@ -276,7 +273,7 @@ extension MultiPageCoordinator: ExtractionsManagerDelegate {
             alert.addAction(okAction)
             delegate?.multiPageCoordinator(self, requestedShowingController: alert, presentationStyle: .modal, animated: true, completion: nil)
         }
-        currentSwitchSdk().delegate?.switchSdk(sdk: currentSwitchSdk(), didReceiveError: error)
+        currentSwitchSdk().delegate?.switchSdk(currentSwitchSdk(), didReceiveError: error)
     }
     
     func extractionsManager(_ manager:ExtractionsManager, didChangePageCollection collection:PageCollection) {
@@ -302,7 +299,7 @@ extension MultiPageCoordinator: ExtractionsManagerDelegate {
     }
     
     func extractionsManagerDidSendFeedback(_ manager:ExtractionsManager) {
-        currentSwitchSdk().delegate?.switchSdkDidSendFeedback(sdk: currentSwitchSdk())
+        currentSwitchSdk().delegate?.switchSdkDidSendFeedback(currentSwitchSdk())
     }
     
 }

--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -64,15 +64,11 @@ The Gini Switch SDK uses the Delegate design pattern to notify the host app abou
 ```swift
 public protocol GiniSwitchSdkDelegate: class {
 
-    func switchSdkDidStart(sdk:GiniSwitchSdk)
-    func switchSdk(sdk:GiniSwitchSdk, didCapture imageData:Data)
-    func switchSdk(sdk:GiniSwitchSdk, didUpload imageData:Data)
-    func switchSdk(sdk:GiniSwitchSdk, didReview imageData:Data)
-    func switchSdkDidComplete(sdk:GiniSwitchSdk)
-    func switchSdk(sdk:GiniSwitchSdk, didExtractInfo info:ExtractionCollection)
-    func switchSdk(sdk:GiniSwitchSdk, didReceiveError error:Error)
-    func switchSdk(sdk:GiniSwitchSdk, didFailWithError error:Error)
-    func switchSdkDidCancel(sdk:GiniSwitchSdk)
+    func switchSdk(_ sdk:GiniSwitchSdk, didChangeExtractions extractions:ExtractionCollection)
+    func switchSdk(_ sdk:GiniSwitchSdk, didReceiveError error:NSError)
+    func switchSdkDidCancel(_ sdk:GiniSwitchSdk)
+    func switchSdkDidComplete(_ sdk:GiniSwitchSdk)
+    func switchSdkDidSendFeedback(_ sdk:GiniSwitchSdk)
 
 }
 ```
@@ -80,9 +76,9 @@ public protocol GiniSwitchSdkDelegate: class {
 Out of those, as a minimum, the following need to be handled:
 
 ```swift
-func switchSdkDidComplete(sdk:GiniSwitchSdk)
-func switchSdk(sdk:GiniSwitchSdk, didFailWithError error:Error)
-func switchSdkDidCancel(sdk:GiniSwitchSdk)
+func switchSdk(_ sdk:GiniSwitchSdk, didReceiveError error:NSError)
+func switchSdkDidCancel(_ sdk:GiniSwitchSdk)
+func switchSdkDidComplete(_ sdk:GiniSwitchSdk)
 ```
 
 That's where the SDK will be done and it will need to be dismissed.
@@ -92,7 +88,7 @@ That's where the SDK will be done and it will need to be dismissed.
 Naturally, the whole point in displaying the Gini Switch SDK is to get extractions. This is achieved via the
 
 ```swift
-func switchSdk(sdk:GiniSwitchSdk, didExtractInfo info:ExtractionCollection)
+func switchSdk(_ sdk:GiniSwitchSdk, didChangeExtractions extractions:ExtractionCollection)
 ```
 
 method. It can be called multiple time throughout the lifecycle of the SDK - every time there's a change in the extractions. When our service determines that the extractions are complete, it will also call the `switchSdkDidComplete` delegate method. However, even before that, if the host app can determine that it has everything it needs, it is free to dismiss the SDK and continue on its own.
@@ -119,19 +115,19 @@ sdk.sendFeedback(feedback)
 After that, the SDK will send the updated fields to our backend. Upon completion the
 
 ```swift
-func switchSdkDidSendFeedback(sdk:GiniSwitchSdk)
+func switchSdkDidSendFeedback(_ sdk:GiniSwitchSdk)
 ```
 
 will be invoked. Please note that it will be called only if the feedback is successfully received by the backend. if not, the
 
 ```swift
-func switchSdk(sdk:GiniSwitchSdk, didReceiveError error:Error)
+func switchSdk(_ sdk:GiniSwitchSdk, didReceiveError error:NSError)
 ```
 
 will be called with an error type of `feedbackError`. In the Gini Switch SDK example app this is handled in the following way:
 
 ```swift
-func switchSdk(sdk:GiniSwitchSdk, didReceiveError error:NSError) {
+func switchSdk(_ sdk:GiniSwitchSdk, didReceiveError error:NSError) {
   print("Switch SDK did receive an error: \(error.localizedDescription)")
   if error.switchErrorCode == .feedbackError {
     switchController = nil


### PR DESCRIPTION
# Introduction

This is part of @kikettas 's feedback regarding integrating the SDK. For all delegate methods, the first named parameter wasn't needed, because it just repeated the word "SDK". Also, the delegate method that returns the extractions had a misleading name.

# How to test

You don't need to. Method names are checked by the compiler ;)

# Merge info

Automatic