### PR TITLE
Empty feedback

### DIFF
--- a/GiniSwitchSDK/GiniSwitchSDK/Classes/ExtractionCollection+Feedback.swift
+++ b/GiniSwitchSDK/GiniSwitchSDK/Classes/ExtractionCollection+Feedback.swift
@@ -19,17 +19,6 @@ extension ExtractionCollection {
         return (try? JSONSerialization.data(withJSONObject: jsonDict, options: JSONSerialization.WritingOptions.prettyPrinted)) ?? Data()
     }
     
-    func collectionWithDifferences(otherCollection:ExtractionCollection) -> ExtractionCollection {
-        let differences = otherCollection.extractions.filter { (extraction) -> Bool in
-            return !self.extractions.contains(extraction)
-        }
-        return ExtractionCollection(collection: differences)
-    }
-    
-    static func feedbackJsonFor(feedback:ExtractionCollection, original:ExtractionCollection) -> Data {
-        let difference = original.collectionWithDifferences(otherCollection: feedback)
-        return difference.feedbackJson()
-    }
 }
 
 extension Extraction {

--- a/GiniSwitchSDK/GiniSwitchSDK/Classes/ExtractionResources.swift
+++ b/GiniSwitchSDK/GiniSwitchSDK/Classes/ExtractionResources.swift
@@ -119,11 +119,11 @@ class ExtractionResources {
         })
     }
     
-    func feebackFor(orderUrl:String, extractions:ExtractionCollection, feedback:ExtractionCollection) -> Resource<Bool> {
+    func feebackFor(orderUrl:String, feedback:ExtractionCollection) -> Resource<Bool> {
         var fullUrl = URL(string:orderUrl)!
         fullUrl = fullUrl.appendingPathComponent(extractionsExtension)
         let authHeaders = Token.bearerAuthHeadersDictWith(token: token)
-        let body = ExtractionCollection.feedbackJsonFor(feedback: feedback, original: extractions)
+        let body = feedback.feedbackJson()
         return Resource<Bool>(url: fullUrl, headers: authHeaders, method: "PUT", body: body, parseJSON: { (json) -> Bool? in
             return true
         })

--- a/GiniSwitchSDK/GiniSwitchSDK/Classes/ExtractionService.swift
+++ b/GiniSwitchSDK/GiniSwitchSDK/Classes/ExtractionService.swift
@@ -90,12 +90,12 @@ class ExtractionService {
         }
     }
     
-    func sendFeedback(original:ExtractionCollection, feedback:ExtractionCollection, completion:@escaping ExtractionServiceFeedbackCallback) {
+    func sendFeedback(_ feedback:ExtractionCollection, completion:@escaping ExtractionServiceFeedbackCallback) {
         guard let order = orderUrl else {
             // no extraction order anymore
             return
         }
-        resourceLoader.load(resource: resources.feebackFor(orderUrl: order, extractions: original, feedback: feedback)) { (response, error) in
+        resourceLoader.load(resource: resources.feebackFor(orderUrl: order, feedback: feedback)) { (response, error) in
             completion(error)
         }
     }

--- a/GiniSwitchSDK/GiniSwitchSDK/Classes/ExtractionsManager.swift
+++ b/GiniSwitchSDK/GiniSwitchSDK/Classes/ExtractionsManager.swift
@@ -197,7 +197,14 @@ class ExtractionsManager {
         guard hasActiveSession else {
             return
         }
-        
+        let differences = extractions.collectionWithDifferences(otherCollection: feedback)
+        guard !differences.extractions.isEmpty else {
+            // if users don't check if the feedback doesn't contain no changes, they will call the
+            // sendFeedback method and expect a callback when it's done. So the callback is called
+            // explicitly here and it is "assumed" that it was successful
+            notifyFeedbackSent()
+            return
+        }
         uploadService?.sendFeedback(original: extractions, feedback: feedback, completion: { [weak self] (error) in
             if let error = error {
                 Logger().logError(message: "Sending feedback failed: \(error.localizedDescription)")
@@ -205,6 +212,7 @@ class ExtractionsManager {
             }
             else {
                 Logger().logInfo(message: "Feedback sent!")
+                self?.notifyFeedbackSent()
             }
         })
     }

--- a/GiniSwitchSDK/GiniSwitchSDK/Classes/ExtractionsManager.swift
+++ b/GiniSwitchSDK/GiniSwitchSDK/Classes/ExtractionsManager.swift
@@ -197,15 +197,14 @@ class ExtractionsManager {
         guard hasActiveSession else {
             return
         }
-        let differences = extractions.collectionWithDifferences(otherCollection: feedback)
-        guard !differences.extractions.isEmpty else {
-            // if users don't check if the feedback doesn't contain no changes, they will call the
+        guard !feedback.extractions.isEmpty else {
+            // if users don't check if the feedback doesn't contain any extractions, they will call the
             // sendFeedback method and expect a callback when it's done. So the callback is called
             // explicitly here and it is "assumed" that it was successful
             notifyFeedbackSent()
             return
         }
-        uploadService?.sendFeedback(original: extractions, feedback: feedback, completion: { [weak self] (error) in
+        uploadService?.sendFeedback(feedback, completion: { [weak self] (error) in
             if let error = error {
                 Logger().logError(message: "Sending feedback failed: \(error.localizedDescription)")
                 self?.handleError(error, ofType: .feedbackError)


### PR DESCRIPTION
# Introduction

Added a check to ExtractionsManager to see if there is any changed field in the feedback users are trying to send. If there is no feedback, no request is sent and the feedback success delegate method is invoked.

# Merge Info

Automatic