### PR TITLE
Recreating users if the server rejects them

### DIFF
--- a/GiniSwitchSDK/Example/Tests/AuthenticatorTests.swift
+++ b/GiniSwitchSDK/Example/Tests/AuthenticatorTests.swift
@@ -30,22 +30,4 @@ class AuthenticatorTests: XCTestCase {
         XCTAssertEqual(tokenResource.headers["Authorization"], "Basic dGVzdElkOnNlY3JldA==", "The client token request should have a basic authentication header")
     }
     
-    func testCreatingUser() {
-        auth.clientToken = "testToken"
-        let userResource = auth.createUser
-        XCTAssertEqual(userResource.url, URL(string: "\(auth.baseUrl.absoluteString)/api/users"), "The create user request URL doesn't match")
-        XCTAssertEqual(userResource.method, "POST", "The create user request method doesn't match")
-        XCTAssertEqual(String(data: userResource.body!, encoding: .utf8), "{\n  \"password\" : \"\(auth.user?.password ?? "")\",\n  \"email\" : \"\(auth.user?.email ?? "")\"\n}", "The create user request should contain user credentials in it's payload")
-        XCTAssertEqual(userResource.headers["Authorization"], "Bearer testToken", "The create user request should have a bearer authentication header")
-    }
-    
-    func testLoggingInUser() {
-        auth.user = User(email: "test@gini.net", password: "password")
-        let userResource = auth.userLogin
-        XCTAssertEqual(userResource.url, URL(string: "\(auth.baseUrl.absoluteString)/oauth/token?grant_type=password"), "The login user request URL doesn't match")
-        XCTAssertEqual(userResource.method, "POST", "The create user request method doesn't match")
-        XCTAssertEqual(String(data: userResource.body!, encoding: .utf8), "username=test@gini.net&password=password", "The login user request should contain user credentials in it's payload")
-        XCTAssertEqual(userResource.headers["Authorization"], "Basic dGVzdElkOnNlY3JldA==", "The login user request should have a bearer authentication header")
-    }
-    
 }

--- a/GiniSwitchSDK/GiniSwitchSDK/Classes/CredentialsStore.swift
+++ b/GiniSwitchSDK/GiniSwitchSDK/Classes/CredentialsStore.swift
@@ -34,7 +34,7 @@ class KeychainCredentialsStore : CredentialsStore {
                 _ = save(service: accessTokenService, userName: tokenAccountField, secret: token)
             }
             else {
-                _ = delete(service: accessTokenService)
+                delete(service: accessTokenService)
             }
         }
         get {
@@ -46,7 +46,7 @@ class KeychainCredentialsStore : CredentialsStore {
         set {
             // TODO: if nil is set, delete the token?
             // TODO: look at the returned value
-            _ = save(service: refreshTokenService, userName: tokenAccountField, secret: newValue ?? "")
+            save(service: refreshTokenService, userName: tokenAccountField, secret: newValue ?? "")
         }
         get {
             return load(service: refreshTokenService, accountName: tokenAccountField)?.secret
@@ -57,7 +57,7 @@ class KeychainCredentialsStore : CredentialsStore {
         set {
             // TODO: if nil is set, delete the token?
             // TODO: look at the returned value
-            _ = save(service: expirationService, userName: tokenAccountField, secret: "\(newValue ?? 0)")
+            save(service: expirationService, userName: tokenAccountField, secret: "\(newValue ?? 0)")
         }
         get {
             guard let expirationString = load(service: expirationService, accountName: tokenAccountField)?.secret else {
@@ -74,7 +74,7 @@ class KeychainCredentialsStore : CredentialsStore {
                     _ = delete(service: userService)
                     return
             }
-            _ = save(service: userService, userName: email, secret: password)
+            save(service: userService, userName: email, secret: password)
         }
         get {
             if let (username, pass) = load(service: userService),
@@ -89,7 +89,7 @@ class KeychainCredentialsStore : CredentialsStore {
 
 extension CredentialsStore {
     
-    func save(service: String, userName: String, secret: String) -> Bool {
+    func save(service: String, userName: String, secret: String) {
         let keychainQuery = queryFor(service: service, secret: secret)
         SecItemDelete(keychainQuery as CFDictionary)
         // Note that it was important to delete the old entries BEFORE specifying the user name.
@@ -97,14 +97,12 @@ extension CredentialsStore {
         keychainQuery[kSecAttrAccount as NSString] = userName
         
         // Add the new keychain item
-        let status = SecItemAdd(keychainQuery as CFDictionary, nil)
-        return (status == errSecSuccess)
+        SecItemAdd(keychainQuery as CFDictionary, nil)
     }
     
-    func delete(service: String) -> Bool {
+    func delete(service: String) {
         let keychainQuery = queryFor(service: service)
-        let status = SecItemDelete(keychainQuery as CFDictionary)
-        return (status == errSecSuccess)
+        SecItemDelete(keychainQuery as CFDictionary)
     }
     
     func load(service: String, accountName:String? = nil) -> (accountName:String?, secret:String)? {

--- a/GiniSwitchSDK/GiniSwitchSDK/Classes/CredentialsStore.swift
+++ b/GiniSwitchSDK/GiniSwitchSDK/Classes/CredentialsStore.swift
@@ -30,9 +30,12 @@ class KeychainCredentialsStore : CredentialsStore {
     
     var accessToken:String? {
         set {
-            // TODO: if nil is set, delete the token?
-            // TODO: look at the returned value
-            _ = save(service: accessTokenService, userName: tokenAccountField, secret: newValue ?? "")
+            if let token = newValue {
+                _ = save(service: accessTokenService, userName: tokenAccountField, secret: token)
+            }
+            else {
+                _ = delete(service: accessTokenService)
+            }
         }
         get {
             return load(service: accessTokenService, accountName: tokenAccountField)?.secret
@@ -68,6 +71,7 @@ class KeychainCredentialsStore : CredentialsStore {
         set {
             guard let email = newValue?.email,
                 let password = newValue?.password else {
+                    _ = delete(service: userService)
                     return
             }
             _ = save(service: userService, userName: email, secret: password)
@@ -86,22 +90,20 @@ class KeychainCredentialsStore : CredentialsStore {
 extension CredentialsStore {
     
     func save(service: String, userName: String, secret: String) -> Bool {
-        guard let dataFromString = secret.data(using: String.Encoding.utf8, allowLossyConversion: false) else {
-            // TODO: this is probably a serious error, but not a fatal one
-            return false
-        }
-        // Instantiate a new default keychain query
-        let keychainQuery: NSMutableDictionary = NSMutableDictionary(objects: [kSecClassGenericPassword, service, dataFromString], forKeys: [kSecClass as NSString, kSecAttrService as NSString, kSecValueData as NSString])
-        
-        // Delete any existing items
+        let keychainQuery = queryFor(service: service, secret: secret)
         SecItemDelete(keychainQuery as CFDictionary)
-        
         // Note that it was important to delete the old entries BEFORE specifying the user name.
         // Otherwise, if a user with a different name is saved, the old one will remain in the keychain
         keychainQuery[kSecAttrAccount as NSString] = userName
         
         // Add the new keychain item
         let status = SecItemAdd(keychainQuery as CFDictionary, nil)
+        return (status == errSecSuccess)
+    }
+    
+    func delete(service: String) -> Bool {
+        let keychainQuery = queryFor(service: service)
+        let status = SecItemDelete(keychainQuery as CFDictionary)
         return (status == errSecSuccess)
     }
     
@@ -127,6 +129,16 @@ extension CredentialsStore {
             }
         }
         return nil
+    }
+    
+    func queryFor(service: String, secret: String? = nil) -> NSMutableDictionary {
+        let keychainQuery: NSMutableDictionary = NSMutableDictionary(objects: [kSecClassGenericPassword, service], forKeys: [kSecClass as NSString, kSecAttrService as NSString])
+        
+        if let pass = secret,
+            let dataFromString = pass.data(using: String.Encoding.utf8, allowLossyConversion: false) {
+            keychainQuery.setObject(dataFromString, forKey: kSecValueData as NSString)
+        }
+        return keychainQuery
     }
     
 }

--- a/GiniSwitchSDK/GiniSwitchSDK/Classes/Error.swift
+++ b/GiniSwitchSDK/GiniSwitchSDK/Classes/Error.swift
@@ -15,6 +15,7 @@ public enum GiniSwitchErrorCode: Int {
     case network
     case authentication
     case tokenExpired
+    case grantInvalid
     case invalidResponse
     
     // high level error
@@ -85,6 +86,11 @@ extension NSError {
     func isTokenExpiredError() -> Bool {
         return NSError.switchErrorCode(apiCode: code) == .tokenExpired ||
             errorName() == "invalid_token"      // TODO: don't rely on names - check the code only
+    }
+    
+    func isInvalidUserError() -> Bool {
+        return NSError.switchErrorCode(apiCode: code) == .grantInvalid ||
+        errorName() == "invalid_grant"
     }
 }
 

--- a/GiniSwitchSDK/GiniSwitchSDK/Classes/Error.swift
+++ b/GiniSwitchSDK/GiniSwitchSDK/Classes/Error.swift
@@ -15,7 +15,6 @@ public enum GiniSwitchErrorCode: Int {
     case network
     case authentication
     case tokenExpired
-    case grantInvalid
     case invalidResponse
     
     // high level error
@@ -89,8 +88,7 @@ extension NSError {
     }
     
     func isInvalidUserError() -> Bool {
-        return NSError.switchErrorCode(apiCode: code) == .grantInvalid ||
-        errorName() == "invalid_grant"
+        return errorName() == "invalid_grant"
     }
 }
 

--- a/GiniSwitchSDK/GiniSwitchSDK/Classes/ExtractionsManager.swift
+++ b/GiniSwitchSDK/GiniSwitchSDK/Classes/ExtractionsManager.swift
@@ -88,7 +88,7 @@ class ExtractionsManager {
     
     func createExtractionOrder() {
         guard authenticator?.isLoggedIn == true,
-        let token = authenticator?.userToken else {
+        let token = authenticator?.credentials.accessToken else {
             // not logged in
             shouldRequestOrder = true
             return

--- a/GiniSwitchSDK/GiniSwitchSDK/Classes/UserManager.swift
+++ b/GiniSwitchSDK/GiniSwitchSDK/Classes/UserManager.swift
@@ -32,7 +32,9 @@ struct UserManager {
         }
         
         // generate a new one, if there is no user
-        return createNewUser()
+        let user = createNewUser()
+        credentials.user = user
+        return user
     }
     
     private func createNewUser() -> User {


### PR DESCRIPTION
# Introduction

It is possible that the client has a user pre-cached in its keychain, but it is no longer valid on the server. For instance, if the client switches from stage to production or if we have a problem with out database. To cover those cases, if the client receives an "invalid_grant" error while logging in a user, a new user will be generated and login will start again.

# How to test

Switch to stage, start the app and make sure it authenticates and can upload pics. Then switch to production, run the app and make sure it can re-authentica with a new user and you can freely upload pics again.

# Merge info

Automatics.