### PR TITLE
Feature processing state

### DIFF
--- a/GiniSwitchSDK/GiniSwitchSDK/Classes/ExtractionCollection.swift
+++ b/GiniSwitchSDK/GiniSwitchSDK/Classes/ExtractionCollection.swift
@@ -10,7 +10,7 @@ import UIKit
 
 public class ExtractionCollection:BaseApiResponse {
 
-    public let extractions:[Extraction]
+    public var extractions:[Extraction]
     
     public init() {
         extractions = []

--- a/GiniSwitchSDK/GiniSwitchSDK/Classes/ExtractionsManager.swift
+++ b/GiniSwitchSDK/GiniSwitchSDK/Classes/ExtractionsManager.swift
@@ -48,6 +48,12 @@ class ExtractionsManager {
             (uploadService?.hasExtractionOrder ?? false)
     }
     
+    var isProcessing:Bool {
+        return scannedPages.pages.reduce(false) { (processing, currentPage) in
+            return processing || (currentPage.status != .analysed && currentPage.status != .failed)
+        }
+    }
+    
     var hasCredentials:Bool {
         return (!clientId.isEmpty && !clientSecret.isEmpty && !clientDomain.isEmpty)
     }

--- a/GiniSwitchSDK/GiniSwitchSDK/Classes/GiniSwitchSdk.swift
+++ b/GiniSwitchSDK/GiniSwitchSDK/Classes/GiniSwitchSdk.swift
@@ -33,6 +33,16 @@ public class GiniSwitchSdk {
     /// Contains some configuration objects that can be used to customize the SDK
     public var configuration = GiniSwitchConfiguration()
     
+    /*
+     * Indicates that the SDK is currently processing images (or not).
+     * "Processing" might mean uploading or analysing the image.
+     * Additionally, images currently being reviewed are also considered processing.
+     * Images marked as "failed", are NOT considered processing.
+     */
+    public var isProcessing:Bool {
+        return extractionsManager.isProcessing
+    }
+    
     let extractionsManager:ExtractionsManager
     var coordinator:MultiPageCoordinator? = nil
     

--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -139,6 +139,16 @@ func switchSdk(_ sdk:GiniSwitchSdk, didReceiveError error:NSError) {
 
 To properly dispose of the SDK after feedback is sent, wait until the `switchSdkDidSendFeedback` or the `didReceiveError` (with a `feedbackError` error type) to be invoked. Once that happens, terminate the SDK as described in [Dismiss the SDK](#dismiss-sdk).
 
+#### Adding missing extractions
+
+If you receive extractions from the Switch SDK, but realize that something's missing, you can add that field as part of the feedback to let us know that we failed to extract something from the document. To do that, create an `Extraction` object with the desired values and add it to the `extractions` array in your `ExtractionCollection`. For example:
+
+```swift
+let missingExtraction = Extraction(name: "companyName", value: "Stadtwerke Gini")
+feedback.extractions.append(missingExtraction)
+sdk?.sendFeedback(feedback)
+```
+
 ## SDK Customizations
 
 The Gini Switch SDK is designed to be an independent part of the hosting application. The overall UI and UX is fixed, but some parameters are customizable.

--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -144,7 +144,7 @@ To properly dispose of the SDK after feedback is sent, wait until the `switchSdk
 If you receive extractions from the Switch SDK, but realize that something's missing, you can add that field as part of the feedback to let us know that we failed to extract something from the document. To do that, create an `Extraction` object with the desired values and add it to the `extractions` array in your `ExtractionCollection`. For example:
 
 ```swift
-let missingExtraction = Extraction(name: "companyName", value: "Stadtwerke Gini")
+let missingExtraction = Extraction(name: "companyName", value: "Stadtwerke Gini" as AnyObject)
 feedback.extractions.append(missingExtraction)
 sdk?.sendFeedback(feedback)
 ```


### PR DESCRIPTION
# Introduction

It will be helpful for customers to see if the SDK is currently processing any images. Previously, that wasn't super easy to achieve. But now there is an `isProcessing` property in `GiniSwitchSdk` that they can use

# How to test

I put the following code in in the example:

```
var helloWorldTimer = Timer.scheduledTimer(timeInterval: 1.0, target: self, selector: #selector(checkProcessingState), userInfo: nil, repeats: true)        

func checkProcessingState()
{
     print("Processing: \(sdk?.isProcessing)")
}
```

to check contiguously whether or not the SDK reports a processing state or not.

# Merge info

Automatic