### PR TITLE
Bugfix feedback json

### DIFF
--- a/GiniSwitchSDK/Example/GiniTariffSDK/ExtractionsViewController.swift
+++ b/GiniSwitchSDK/Example/GiniTariffSDK/ExtractionsViewController.swift
@@ -65,12 +65,7 @@ extension ExtractionsViewController: UITableViewDataSource {
             // Since the data is shown in a text field, all entries are strings. However, it is
             // important to NOT change the data type in the extraction collection
             // (otherwise the backend might reject the data)
-            var replacementValue:Any = newValue
-            let doubleValue = Double(newValue)
-            if let doubleValue = doubleValue {
-                replacementValue = doubleValue
-            }
-            extraction?.value = ExtractionValue(value: replacementValue, unit: extraction?.value.unit)
+            extraction?.value = ExtractionValue(value: Double(newValue) ?? newValue, unit: extraction?.value.unit)
         }
         
         return cell

--- a/GiniSwitchSDK/Example/GiniTariffSDK/ExtractionsViewController.swift
+++ b/GiniSwitchSDK/Example/GiniTariffSDK/ExtractionsViewController.swift
@@ -62,7 +62,15 @@ extension ExtractionsViewController: UITableViewDataSource {
         cell.nameLabel.text = extraction?.name ?? ""
         cell.valueTextField.text = extraction?.valueString ?? ""
         cell.onExtractionChange = { (newValue: String) -> Void in
-            extraction?.value = ExtractionValue(value: newValue as AnyObject, unit: extraction?.value.unit)
+            // Since the data is shown in a text field, all entries are strings. However, it is
+            // important to NOT change the data type in the extraction collection
+            // (otherwise the backend might reject the data)
+            var replacementValue:Any = newValue
+            let doubleValue = Double(newValue)
+            if let doubleValue = doubleValue {
+                replacementValue = doubleValue
+            }
+            extraction?.value = ExtractionValue(value: replacementValue, unit: extraction?.value.unit)
         }
         
         return cell

--- a/GiniSwitchSDK/GiniSwitchSDK/Classes/ExtractionCollection+Feedback.swift
+++ b/GiniSwitchSDK/GiniSwitchSDK/Classes/ExtractionCollection+Feedback.swift
@@ -13,7 +13,7 @@ extension ExtractionCollection {
     func feedbackJson() -> Data {
         let jsonDict = extractions.reduce(JSONDictionary()) { (jsonDict:JSONDictionary, extraction) -> JSONDictionary in
             var newDict = jsonDict
-            newDict[extraction.name] = extraction.jsonDict as AnyObject
+            newDict[extraction.name] = extraction.jsonDict
             return newDict
         }
         return (try? JSONSerialization.data(withJSONObject: jsonDict, options: JSONSerialization.WritingOptions.prettyPrinted)) ?? Data()

--- a/GiniSwitchSDK/GiniSwitchSDK/Classes/ExtractionValue.swift
+++ b/GiniSwitchSDK/GiniSwitchSDK/Classes/ExtractionValue.swift
@@ -32,8 +32,10 @@ public struct ExtractionValue {
         // Also, the value might be a value/unit pair
         if let json = dictionary[ExtractionValue.valueKey] as? JSONDictionary,
             let jsonValue = json[ExtractionValue.valueKey],
+            let jsonUnit = json[ExtractionValue.unitKey],
+            let unit = jsonUnit as? String,
             let value = jsonValue {
-            self.init(value:value, unit: dictionary[ExtractionValue.unitKey] as? String)
+            self.init(value:value, unit: unit)
         }
         // Lastly, the value might be just a top level object
         else {


### PR DESCRIPTION
# Introduction

In `ExtractionsViewController` all changed extraction values were being converted to string. That might be a problem for the backend because they reject numbers that are represented by a string in the JSON.

Since it will be the user's responsibility to implement the `ExtractionsViewController` functionality in their app, this pull request will not be enough - we need to validate that they keep the data type and reflect that in the documentation.

# How to test

Go to the extractions screen and change the value of a numeric field. Tap on "Switch" to send the feedback and see of the server accepts the changes.