### PR TITLE
iOS11 Simulator video device crash

### DIFF
--- a/GiniSwitchSDK/GiniSwitchSDK/Classes/Camera.swift
+++ b/GiniSwitchSDK/GiniSwitchSDK/Classes/Camera.swift
@@ -116,8 +116,11 @@ internal class Camera {
         }
         
         let videoDevice = deviceWithMediaType(AVMediaType.video.rawValue, preferringPosition: .back)
+        guard let device = videoDevice else {
+            return
+        }
         do {
-            self.videoDeviceInput = try AVCaptureDeviceInput(device: videoDevice!)
+            self.videoDeviceInput = try AVCaptureDeviceInput(device: device)
         } catch let error as NSError {
             print("Could not create video device input \(error)")
             if error.code == AVError.Code.applicationIsNotAuthorizedToUseDevice.rawValue {


### PR DESCRIPTION
# Introduction

The example app was crashing on the simulator on iOS11 because of a nil optional regarding video devices. I added a guard statement to make sure it doesn't happen.

# How to test

Run the app in the simulator and see if it crashes on the camera screen.

# Merge info

Automatic.